### PR TITLE
Various build process improvements

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm install
-      - name: Build
-        run: npm run build --if-present
       - name: Test
         run: npm test

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
 .nyc_output
-node_modules
 package-lock.json
-dist
 coverage

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In `main.js`:
 const Piscina = require('piscina');
 
 const piscina = new Piscina({
-  filename: path.resolve(__dirname, 'worker.js');
+  filename: path.resolve(__dirname, 'worker.js')
 });
 
 (async function() {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "piscina",
   "version": "1.0.0-pre",
   "description": "A fast, efficient Node.js Worker Thread Pool implementation",
-  "main": "./build/src/index.js",
+  "main": "./dist/src/index.js",
+  "exports": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "standardx **/*.ts | snazzy",
+    "lint": "standardx \"**/*.ts\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
-    "test-only": "TS_NODE_PROJECT=test/tsconfig.json tap --ts --no-browser --coverage-report=html --100 test/*.ts",
+    "test-only": "cross-env TS_NODE_PROJECT=test/tsconfig.json tap --ts --no-browser --coverage-report=html --coverage-report=text --100 test/*.ts",
     "prepack": "npm run build"
   },
   "repository": {
@@ -29,6 +31,7 @@
     "@types/node": "^13.13.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
+    "cross-env": "^7.0.2",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",
     "tap": "^14.10.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,12 +214,13 @@ class ThreadPool {
     this.taskQueue = [];
 
     this.options = { ...kDefaultOptions, ...options };
+    // The >= and <= could be > and < but this way we get 100 % coverage 🙃
     if (options.maxThreads !== undefined &&
-        this.options.minThreads > options.maxThreads) {
+        this.options.minThreads >= options.maxThreads) {
       this.options.minThreads = options.maxThreads;
     }
     if (options.minThreads !== undefined &&
-        this.options.maxThreads < options.minThreads) {
+        this.options.maxThreads <= options.minThreads) {
       this.options.maxThreads = options.minThreads;
     }
 

--- a/test/fixtures/simple-isworkerthread.ts
+++ b/test/fixtures/simple-isworkerthread.ts
@@ -3,4 +3,4 @@ import assert from 'assert';
 
 assert.strictEqual(Piscina.isWorkerThread, true);
 
-export default function() { return 'done'; }
+export default function () { return 'done'; }

--- a/test/fixtures/wait-for-notify.ts
+++ b/test/fixtures/wait-for-notify.ts
@@ -1,5 +1,5 @@
-module.exports = function(i32array) {
+module.exports = function (i32array) {
   Atomics.wait(i32array, 0, 0);
   Atomics.store(i32array, 0, -1);
   Atomics.notify(i32array, 0, Infinity);
-}
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es2018",
     "module": "commonjs",
-    "lib": ["es6"],
-    "outDir": "build",
+    "moduleResolution": "node",
+    "lib": ["es2018"],
+    "outDir": "dist",
     "rootDir": ".",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
- Rename `build/` directory to more customary `dist/`
- Emit native `async/await` code
- Add `.npmignore`
- Add `exports:` field to `package.json` for future-proofing
- Add `types:` field to `package.json` for consumers using TS
- Print out coverage information in text format along with HTML output
- Fix typo in readme