### PR TITLE
Support AbortController / AbortSignal

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,13 @@
+check-coverage: true
+color: true
+coverage: true
+coverage-report:
+  - html
+  - text
+jobs: 2
+no-browser: true
+test-env: TS_NODE_PROJECT=test/tsconfig.json
+test-ignore: $.
+test-regex: ((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|[jt]sx?)$
+timeout: 30
+ts: true

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This class extends [`EventEmitter`][] from Node.js.
   * `useAtomics`: (`boolean`) Use the [`Atomics`][] API for faster communication
     between threads. This is on by default.
 
-### Method: `runTask(task[, transferList][, filename])`
+### Method: `runTask(task[, transferList][, filename][, abortSignal])`
 
 Schedules a task to be run on a Worker thread.
 
@@ -79,10 +79,17 @@ Schedules a task to be run on a Worker thread.
 * `filename`: Optionally overrides the `filename` option passed to the
   constructor for this task. If no `filename` was specified to the constructor,
   this is mandatory.
+* `abortSignal`: An [`AbortSignal`][] instance. If passed, this can be used to
+  cancel a task, including already running ones.
+  (More generally, any `EventEmitter` or `EventTarget` that emits `'abort'`
+  events can be passed here.) Abortable tasks cannot share threads regardless
+  of the `concurrentTasksPerWorker` options.
 
 This returns a `Promise` for the return value of the (async) function call
 made to the function exported from `filename`. If the (async) function throws
 an error, the returned `Promise` will be rejected with that error.
+If the task is aborted, the returned `Promise` is rejected with an error
+as well.
 
 ### Method: `destroy()`
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Schedules a task to be run on a Worker thread.
   constructor for this task. If no `filename` was specified to the constructor,
   this is mandatory.
 * `abortSignal`: An [`AbortSignal`][] instance. If passed, this can be used to
-  cancel a task, including already running ones.
+  cancel a task. If the task is already running, the corresponding `Worker`
+  thread will be stopped.
   (More generally, any `EventEmitter` or `EventTarget` that emits `'abort'`
   events can be passed here.) Abortable tasks cannot share threads regardless
   of the `concurrentTasksPerWorker` options.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "lint": "standardx \"**/*.ts\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
-    "test-only": "cross-env TS_NODE_PROJECT=test/tsconfig.json tap --ts --no-browser --coverage-report=html --coverage-report=text --100 --jobs=2 test/*.ts",
+    "test-only": "tap",
     "prepack": "npm run build"
   },
   "repository": {
@@ -32,7 +32,6 @@
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "abort-controller": "^3.0.0",
-    "cross-env": "^7.0.2",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",
     "tap": "^14.10.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc",
     "lint": "standardx \"**/*.ts\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
-    "test-only": "cross-env TS_NODE_PROJECT=test/tsconfig.json tap --ts --no-browser --coverage-report=html --coverage-report=text --100 test/*.ts",
+    "test-only": "cross-env TS_NODE_PROJECT=test/tsconfig.json tap --ts --no-browser --coverage-report=html --coverage-report=text --100 --jobs=2 test/*.ts",
     "prepack": "npm run build"
   },
   "repository": {
@@ -31,6 +31,7 @@
     "@types/node": "^13.13.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
+    "abort-controller": "^3.0.0",
     "cross-env": "^7.0.2",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,11 @@ class ThreadPool {
 
     if (abortSignal !== null) {
       onabort(abortSignal, () => {
+        // Call reject() first to make sure we always reject with the AbortError
+        // if the task is aborted, not with an Error from the possible
+        // thread termination below.
         reject(new AbortError());
+
         if (taskInfo.workerInfo !== null) {
           // Already running: We cancel the Worker this is running on.
           this._removeWorker(taskInfo.workerInfo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,26 @@ const cpuCount : number = (() => {
   }
 })();
 
+interface AbortSignalEventTarget {
+  addEventListener : (name : 'abort', listener : () => void) => void;
+}
+interface AbortSignalEventEmitter {
+  on : (name : 'abort', listener : () => void) => void;
+}
+type AbortSignalAny = AbortSignalEventTarget | AbortSignalEventEmitter;
+function onabort (abortSignal : AbortSignalAny, listener : () => void) {
+  if ('addEventListener' in abortSignal) {
+    abortSignal.addEventListener('abort', listener);
+  } else {
+    abortSignal.on('abort', listener);
+  }
+}
+class AbortError extends Error {
+  constructor () {
+    super('The task has been aborted');
+  }
+}
+
 interface Options {
   // Probably also support URL here
   filename? : string | null,
@@ -67,18 +87,22 @@ class TaskInfo extends AsyncResource {
   transferList : TransferList;
   filename : string;
   taskId : number;
+  abortSignal : AbortSignalAny | null;
+  workerInfo : WorkerInfo | null = null;
 
   constructor (
     task : any,
     transferList : TransferList,
     filename : string,
-    callback : TaskCallback) {
+    callback : TaskCallback,
+    abortSignal : AbortSignalAny | null) {
     super('Piscina.Task', { requireManualDestroy: false });
     this.callback = callback;
     this.task = task;
     this.transferList = transferList;
     this.filename = filename;
     this.taskId = taskIdCounter++;
+    this.abortSignal = abortSignal;
   }
 
   releaseTask () : any {
@@ -173,6 +197,7 @@ class WorkerInfo {
       return;
     }
 
+    taskInfo.workerInfo = this;
     this.taskInfos.set(taskInfo.taskId, taskInfo);
     this.ref();
     this.clearIdleTimeout();
@@ -199,6 +224,13 @@ class WorkerInfo {
         this._handleResponse(entry.message);
       }
     }
+  }
+
+  isRunningAbortableTask () : boolean {
+    // If there are abortable tasks, we are running one at most per Worker.
+    if (this.taskInfos.size !== 1) return false;
+    const [[, task]] = this.taskInfos;
+    return task.abortSignal !== null;
   }
 }
 
@@ -229,7 +261,7 @@ class ThreadPool {
 
   _ensureMinimumWorkers () : void {
     while (this.workers.length < this.options.minThreads) {
-      this._addNewWorker();
+      this._onWorkerFree(this._addNewWorker());
     }
   }
 
@@ -328,17 +360,17 @@ class ThreadPool {
     }
   }
 
-  // Implement some kind of task cancellation mechanism?
   runTask (
     task : any,
     transferList : TransferList,
-    filename : string | null) : Promise<any> {
+    filename : string | null,
+    abortSignal : AbortSignalAny | null) : Promise<any> {
     if (filename === null) {
       filename = this.options.filename;
     }
-    if (filename === null) {
+    if (typeof filename !== 'string') {
       return Promise.reject(new Error(
-        'filename must be provided to postTask() or in options object'));
+        'filename must be provided to runTask() or in options object'));
     }
 
     let resolve : (result : any) => void;
@@ -352,7 +384,24 @@ class ThreadPool {
         } else {
           resolve(result);
         }
+      },
+      abortSignal);
+
+    if (abortSignal !== null) {
+      onabort(abortSignal, () => {
+        reject(new AbortError());
+        if (taskInfo.workerInfo !== null) {
+          // Already running: We cancel the Worker this is running on.
+          this._removeWorker(taskInfo.workerInfo);
+          this._ensureMinimumWorkers();
+        } else {
+          // Not yet running: Remove it from the queue.
+          const index = this.taskQueue.indexOf(taskInfo);
+          assert.notStrictEqual(index, -1);
+          this.taskQueue.splice(index, 1);
+        }
       });
+    }
 
     // If there is a task queue, there's no point in looking for an available
     // Worker thread. Add this task to the queue, if possible.
@@ -370,7 +419,8 @@ class ThreadPool {
     let workerInfo : WorkerInfo | null = null;
     let minimumCurrentTasks = Infinity;
     for (const candidate of this.workers) {
-      if (candidate.taskInfos.size < minimumCurrentTasks) {
+      if (candidate.taskInfos.size < minimumCurrentTasks &&
+          !candidate.isRunningAbortableTask()) {
         workerInfo = candidate;
         minimumCurrentTasks = candidate.taskInfos.size;
         if (minimumCurrentTasks === 0) break;
@@ -378,7 +428,10 @@ class ThreadPool {
     }
 
     // If all Workers are at maximum usage, do not use any of them.
-    if (minimumCurrentTasks >= this.options.concurrentTasksPerWorker) {
+    // If we want the ability to abort this task, use only workers that have
+    // no running tasks.
+    if (minimumCurrentTasks >= this.options.concurrentTasksPerWorker ||
+        (minimumCurrentTasks > 0 && abortSignal)) {
       workerInfo = null;
     }
 
@@ -466,12 +519,34 @@ class Piscina extends EventEmitter {
     this.#pool = new ThreadPool(this, options);
   }
 
-  runTask (task : any, transferList? : TransferList | string, filename? : string) {
-    if (typeof transferList === 'string') {
+  runTask (task : any, transferList? : TransferList | string | AbortSignalAny, filename? : string | AbortSignalAny, abortSignal? : AbortSignalAny) {
+    // If transferList is a string or AbortSignal, shift it.
+    if ((typeof transferList === 'object' && !Array.isArray(transferList)) ||
+        typeof transferList === 'string') {
+      abortSignal = filename as (AbortSignalAny | undefined);
       filename = transferList;
       transferList = undefined;
     }
-    return this.#pool.runTask(task, transferList, filename || null);
+    // If filename is an AbortSignal, shift it.
+    if (typeof filename === 'object' && !Array.isArray(filename)) {
+      abortSignal = filename;
+      filename = undefined;
+    }
+
+    if (transferList !== undefined && !Array.isArray(transferList)) {
+      return Promise.reject(
+        new TypeError('transferList argument must be an Array'));
+    }
+    if (filename !== undefined && typeof filename !== 'string') {
+      return Promise.reject(
+        new TypeError('filename argument must be a string'));
+    }
+    if (abortSignal !== undefined && typeof abortSignal !== 'object') {
+      return Promise.reject(
+        new TypeError('abortSignal argument must be an object'));
+    }
+    return this.#pool.runTask(
+      task, transferList, filename || null, abortSignal || null);
   }
 
   destroy () {

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -1,0 +1,103 @@
+'use strict';
+
+import { AbortController } from 'abort-controller';
+import { EventEmitter } from 'events';
+import Piscina from '..';
+import { test } from 'tap';
+import { resolve } from 'path';
+
+test('tasks can be aborted through AbortController while running', async ({ is, rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
+  });
+
+  const buf = new Int32Array(new SharedArrayBuffer(4));
+  const abortController = new AbortController();
+  rejects(pool.runTask(buf, abortController.signal),
+    /The task has been aborted/);
+
+  Atomics.wait(buf, 0, 0);
+  is(Atomics.load(buf, 0), 1);
+
+  abortController.abort();
+});
+
+test('tasks can be aborted through EventEmitter while running', async ({ is, rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
+  });
+
+  const buf = new Int32Array(new SharedArrayBuffer(4));
+  const ee = new EventEmitter();
+  rejects(pool.runTask(buf, ee), /The task has been aborted/);
+
+  Atomics.wait(buf, 0, 0);
+  is(Atomics.load(buf, 0), 1);
+
+  ee.emit('abort');
+});
+
+test('tasks can be aborted through EventEmitter before running', async ({ is, rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
+    maxThreads: 1
+  });
+
+  const bufs = [
+    new Int32Array(new SharedArrayBuffer(4)),
+    new Int32Array(new SharedArrayBuffer(4))
+  ];
+  const task1 = pool.runTask(bufs[0]);
+  const ee = new EventEmitter();
+  rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
+  is(pool.queueSize, 1);
+
+  ee.emit('abort');
+
+  // Wake up the thread handling the first task.
+  Atomics.store(bufs[0], 0, 1);
+  Atomics.notify(bufs[0], 0, 1);
+  await task1;
+});
+
+test('abortable tasks will not share workers (abortable posted second)', async ({ is, rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
+    maxThreads: 1,
+    concurrentTasksPerWorker: 2
+  });
+
+  const bufs = [
+    new Int32Array(new SharedArrayBuffer(4)),
+    new Int32Array(new SharedArrayBuffer(4))
+  ];
+  const task1 = pool.runTask(bufs[0]);
+  const ee = new EventEmitter();
+  rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
+  is(pool.queueSize, 1);
+
+  ee.emit('abort');
+
+  // Wake up the thread handling the first task.
+  Atomics.store(bufs[0], 0, 1);
+  Atomics.notify(bufs[0], 0, 1);
+  await task1;
+});
+
+test('abortable tasks will not share workers (abortable posted first)', async ({ is, rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    maxThreads: 1,
+    concurrentTasksPerWorker: 2
+  });
+
+  const ee = new EventEmitter();
+  rejects(pool.runTask('while(true);', ee), /The task has been aborted/);
+  const task2 = pool.runTask('42');
+  is(pool.queueSize, 1);
+
+  ee.emit('abort');
+
+  // Wake up the thread handling the second task.
+  is(await task2, 42);
+});

--- a/test/fixtures/notify-then-sleep.ts
+++ b/test/fixtures/notify-then-sleep.ts
@@ -1,0 +1,5 @@
+module.exports = function (i32array) {
+  Atomics.store(i32array, 0, 1);
+  Atomics.notify(i32array, 0, Infinity);
+  Atomics.wait(i32array, 0, 1);
+};

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -39,3 +39,30 @@ test('postTask() resolves with a rejection when the handler throws', async ({ re
 
   rejects(pool.runTask('throw new Error("foo")'), /foo/);
 });
+
+test('postTask() validates transferList', async ({ rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  rejects(pool.runTask('0', 42 as any),
+    /transferList argument must be an Array/);
+});
+
+test('postTask() validates filename', async ({ rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  rejects(pool.runTask('0', [], 42 as any),
+    /filename argument must be a string/);
+});
+
+test('postTask() validates abortSignal', async ({ rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  rejects(pool.runTask('0', [], undefined, 42 as any),
+    /abortSignal argument must be an object/);
+});

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -76,5 +76,5 @@ test('filename can be null when initially provided', async ({ is }) => {
 test('filename must be provided while posting', async ({ rejects }) => {
   const worker = new Piscina();
   rejects(worker.runTask('doesn’t matter'),
-    /filename must be provided to postTask\(\) or in options object/);
+    /filename must be provided to runTask\(\) or in options object/);
 });


### PR DESCRIPTION
Support AbortController, as well as a Node.js-`EventEmitter`-y variant
of it for people who don’t want to pull in external dependecies or
write their own implementation of it.

Fixes: https://github.com/jasnell/piscina/issues/7