### PR TITLE
scrypt example

### DIFF
--- a/examples/scrypt/README.md
+++ b/examples/scrypt/README.md
@@ -1,0 +1,11 @@
+# scrypt Example
+
+This is an example comparing the performance of pooled and unpooled
+sync and async scrypt operations.
+
+```console
+$ npm run pooled 100
+$ npm run unpooled 100
+$ npm run pooled-sync 100
+$ npm run unpooled-sync 100
+```

--- a/examples/scrypt/monitor.js
+++ b/examples/scrypt/monitor.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { monitorEventLoopDelay } = require('perf_hooks');
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) return;
+
+const monitor = monitorEventLoopDelay({ resolution: 20 });
+
+monitor.enable();
+
+process.on('exit', () => {
+  monitor.disable();
+  console.log('Main Thread Mean/Max/99% Event Loop Delay:',
+              monitor.mean,
+              monitor.max,
+              monitor.percentile(99));
+});

--- a/examples/scrypt/package.json
+++ b/examples/scrypt/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scrypt",
+  "version": "1.0.0",
+  "scripts": {
+    "pooled": "node -r ./monitor pooled",
+    "unpooled": "node -r ./monitor unpooled",
+    "pooled-sync": "node -r ./monitor pooled_sync",
+    "unpooled-sync": "node -r ./monitor unpooled_sync"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "description": ""
+}

--- a/examples/scrypt/pooled.js
+++ b/examples/scrypt/pooled.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const Piscina = require('../../dist/src');
+const { resolve } = require('path');
+const crypto = require('crypto');
+const { promisify } = require('util');
+const randomFill = promisify(crypto.randomFill);
+const { performance, PerformanceObserver } = require('perf_hooks')
+
+const obs = new PerformanceObserver((entries) => {
+  console.log(entries.getEntries()[0].duration)
+});
+obs.observe({ entryTypes: ['measure']});
+
+const piscina = new Piscina({
+  filename: resolve(__dirname, 'scrypt.js'),
+  concurrentTasksPerWorker: 10
+});
+
+async function* generateInput() {
+  let max = parseInt(process.argv[2] || 10);
+  const data = Buffer.allocUnsafe(10);
+  while (max-- > 0) {
+    yield randomFill(data);
+  }
+}
+
+(async function() {
+  performance.mark('start');
+  const keylen = 64;
+
+  for await (const input of generateInput())
+    await piscina.runTask({ input, keylen });
+
+  performance.mark('end');
+  performance.measure('start to end', 'start', 'end');
+})();

--- a/examples/scrypt/pooled_sync.js
+++ b/examples/scrypt/pooled_sync.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Piscina = require('../../dist/src');
+const { resolve } = require('path');
+const crypto = require('crypto');
+const { promisify } = require('util');
+const randomFill = promisify(crypto.randomFill);
+const { performance, PerformanceObserver } = require('perf_hooks')
+
+const obs = new PerformanceObserver((entries) => {
+  console.log(entries.getEntries()[0].duration)
+});
+obs.observe({ entryTypes: ['measure']});
+
+const piscina = new Piscina({
+  filename: resolve(__dirname, 'scrypt_sync.js')
+});
+
+async function* generateInput() {
+  let max = parseInt(process.argv[2] || 10);
+  const data = Buffer.allocUnsafe(10);
+  while (max-- > 0) {
+    yield randomFill(data);
+  }
+}
+
+(async function() {
+  performance.mark('start');
+  const keylen = 64;
+
+  for await (const input of generateInput())
+    await piscina.runTask({ input, keylen });
+
+  performance.mark('end');
+  performance.measure('start to end', 'start', 'end');
+})();

--- a/examples/scrypt/scrypt.js
+++ b/examples/scrypt/scrypt.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const crypto = require('crypto');
+const { promisify } = require('util');
+const scrypt = promisify(crypto.scrypt);
+const randomFill = promisify(crypto.randomFill);
+
+const salt = Buffer.allocUnsafe(16);
+
+module.exports = async function ({
+  input,
+  keylen,
+  N = 16384,
+  r = 8,
+  p = 1,
+  maxmem = 32 * 1024 * 1024 }) {
+    return (await scrypt(
+      input,
+      await randomFill(salt),
+      keylen)).toString('hex');
+};

--- a/examples/scrypt/scrypt_sync.js
+++ b/examples/scrypt/scrypt_sync.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { scryptSync, randomFillSync } = require('crypto');
+
+const salt = Buffer.allocUnsafe(16);
+
+module.exports = function ({
+  input,
+  keylen,
+  N = 16384,
+  r = 8,
+  p = 1,
+  maxmem = 32 * 1024 * 1024 }) {
+    return scryptSync(input, randomFillSync(salt), keylen).toString('hex');
+};

--- a/examples/scrypt/unpooled.js
+++ b/examples/scrypt/unpooled.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const crypto = require('crypto');
+const { promisify } = require('util');
+const randomFill = promisify(crypto.randomFill);
+const scrypt = promisify(crypto.scrypt);
+const { performance, PerformanceObserver } = require('perf_hooks')
+
+const salt = Buffer.allocUnsafe(16);
+
+const obs = new PerformanceObserver((entries) => {
+  console.log(entries.getEntries()[0].duration)
+});
+obs.observe({ entryTypes: ['measure']});
+
+async function* generateInput() {
+  let max = parseInt(process.argv[2] || 10);
+  const data = Buffer.allocUnsafe(10);
+  while (max-- > 0) {
+    yield randomFill(data);
+  }
+}
+
+(async function() {
+  performance.mark('start');
+  const keylen = 64;
+
+  for await (const input of generateInput()) {
+    (await scrypt(input, await randomFill(salt), keylen)).toString('hex');
+  }
+  performance.mark('end');
+  performance.measure('start to end', 'start', 'end');
+})();

--- a/examples/scrypt/unpooled_sync.js
+++ b/examples/scrypt/unpooled_sync.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const crypto = require('crypto');
+const { promisify } = require('util');
+const { scryptSync, randomFillSync } = crypto;
+const randomFill = promisify(crypto.randomFill);
+const { performance, PerformanceObserver } = require('perf_hooks')
+
+const salt = Buffer.allocUnsafe(16);
+
+const obs = new PerformanceObserver((entries) => {
+  console.log(entries.getEntries()[0].duration)
+});
+obs.observe({ entryTypes: ['measure']});
+
+async function* generateInput() {
+  let max = parseInt(process.argv[2] || 10);
+  const data = Buffer.allocUnsafe(10);
+  while (max-- > 0) {
+    yield randomFill(data);
+  }
+}
+
+(async function() {
+  performance.mark('start');
+  const keylen = 64;
+
+  for await (const input of generateInput()) {
+    // Everything in here is intentionally sync
+    scryptSync(input, randomFillSync(salt), keylen).toString('hex');
+  }
+  performance.mark('end');
+  performance.measure('start to end', 'start', 'end');
+})();


### PR DESCRIPTION
@addaleax @mcollina ... this is just a start of an example workload so we can start refining the ideal kinds of workloads for pooling.

```
$ cd examples/scrypt

$ npm run pooled 
// Runs the sample scrypt'ing 1000 randomly generated byte arrays produced
// using an async generator and fed into piscina tasks with the default min/max
// workers. This uses the async version of scrypt and randomFill, which means we're
// also bound to the libuv threadpool.

$ npm run pooled-sync
// Same as above except the sync version of scrypt is used within the worker tasks.

$ npm run unpooled
// Same as pooled except that piscina is not used at all

$ npm run unpooled-sync
// Same as pooled-sync except that piscina is not used at all
```

Each run will output the duration measured with `performance.mark`/`performance.measure`

This isn't necessarily an example we should keep, but it does provide a starting point for reasoning about the kinds of workloads that we should highlight. Please knock this over as much as possible