### PR TITLE
file:// URL + ESM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ This class extends [`EventEmitter`][] from Node.js.
   * `filename`: (`string | null`) Provides the default source for the code that
     runs the tasks on Worker threads. This should be an absolute path or an
     absolute `file://` URL to a file that exports a JavaScript `function` or
-    `async function` as its default export or `module.exports`.
+    `async function` as its default export or `module.exports`. [ES modules][]
+    are supported.
   * `minThreads`: (`number`) Sets the minimum number of threads that are always
     running for this thread pool. The default is based on the number of
     available CPUs.
@@ -357,6 +358,7 @@ Piscina development is sponsored by [NearForm Research][].
 [`Atomics`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics
 [`EventEmitter`]: https://nodejs.org/api/events.html
 [`postMessage`]: https://nodejs.org/api/worker_threads.html#worker_threads_port_postmessage_value_transferlist
+[ES modules]: https://nodejs.org/api/esm.html
 [Node.js new Worker options]: https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options
 [MIT Licensed]: LICENSE.md
 [NearForm Research]: https://www.nearform.com/research/

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ This class extends [`EventEmitter`][] from Node.js.
 
 * The following optional configuration is supported:
   * `filename`: (`string | null`) Provides the default source for the code that
-    runs the tasks on Worker threads. This should be an absolute path to a file
-    that exports a JavaScript `function` or `async function` as its default
-    export or `module.exports`.
+    runs the tasks on Worker threads. This should be an absolute path or an
+    absolute `file://` URL to a file that exports a JavaScript `function` or
+    `async function` as its default export or `module.exports`.
   * `minThreads`: (`number`) Sets the minimum number of threads that are always
     running for this thread pool. The default is based on the number of
     available CPUs.

--- a/examples/abort/index.js
+++ b/examples/abort/index.js
@@ -8,7 +8,7 @@ const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js')
 });
 
-(async function() {
+(async function () {
   const abortController = new AbortController();
   try {
     const task = piscina.runTask({ a: 4, b: 6 }, abortController.signal);

--- a/examples/abort/index2.js
+++ b/examples/abort/index2.js
@@ -8,7 +8,7 @@ const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js')
 });
 
-(async function() {
+(async function () {
   const ee = new EventEmitter();
   try {
     const task = piscina.runTask({ a: 4, b: 6 }, ee);

--- a/examples/es-module/index.mjs
+++ b/examples/es-module/index.mjs
@@ -4,7 +4,7 @@ const piscina = new Piscina({
   filename: new URL('./worker.mjs', import.meta.url).href
 });
 
-(async function() {
+(async function () {
   const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result);  // Prints 10
+  console.log(result); // Prints 10
 })();

--- a/examples/es-module/index.mjs
+++ b/examples/es-module/index.mjs
@@ -1,0 +1,10 @@
+import { Piscina } from 'piscina';
+
+const piscina = new Piscina({
+  filename: new URL('./worker.mjs', import.meta.url).href
+});
+
+(async function() {
+  const result = await piscina.runTask({ a: 4, b: 6 });
+  console.log(result);  // Prints 10
+})();

--- a/examples/es-module/worker.mjs
+++ b/examples/es-module/worker.mjs
@@ -1,0 +1,3 @@
+export default ({ a, b }) => {
+  return a + b;
+};

--- a/examples/message_port/index.js
+++ b/examples/message_port/index.js
@@ -8,11 +8,11 @@ const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js')
 });
 
-(async function() {
+(async function () {
   const channel = new MessageChannel();
   channel.port2.on('message', (message) => {
     console.log(message);
     channel.port2.close();
   });
-  await piscina.runTask({ port: channel.port1 }, [ channel.port1 ]);
+  await piscina.runTask({ port: channel.port1 }, [channel.port1]);
 })();

--- a/examples/resourceLimits/index.js
+++ b/examples/resourceLimits/index.js
@@ -13,7 +13,7 @@ const piscina = new Piscina({
   }
 });
 
-(async function() {
+(async function () {
   try {
     await piscina.runTask();
   } catch (err) {

--- a/examples/scrypt/monitor.js
+++ b/examples/scrypt/monitor.js
@@ -12,7 +12,7 @@ monitor.enable();
 process.on('exit', () => {
   monitor.disable();
   console.log('Main Thread Mean/Max/99% Event Loop Delay:',
-              monitor.mean,
-              monitor.max,
-              monitor.percentile(99));
+    monitor.mean,
+    monitor.max,
+    monitor.percentile(99));
 });

--- a/examples/scrypt/pooled.js
+++ b/examples/scrypt/pooled.js
@@ -5,12 +5,12 @@ const { resolve } = require('path');
 const crypto = require('crypto');
 const { promisify } = require('util');
 const randomFill = promisify(crypto.randomFill);
-const { performance, PerformanceObserver } = require('perf_hooks')
+const { performance, PerformanceObserver } = require('perf_hooks');
 
 const obs = new PerformanceObserver((entries) => {
-  console.log(entries.getEntries()[0].duration)
+  console.log(entries.getEntries()[0].duration);
 });
-obs.observe({ entryTypes: ['measure']});
+obs.observe({ entryTypes: ['measure'] });
 
 const piscina = new Piscina({
   filename: resolve(__dirname, 'scrypt.js'),
@@ -29,7 +29,7 @@ process.on('exit', () => {
   console.log('Wait Time Max:', waitTime.max);
 });
 
-async function* generateInput() {
+async function * generateInput () {
   let max = parseInt(process.argv[2] || 10);
   const data = Buffer.allocUnsafe(10);
   while (max-- > 0) {
@@ -37,12 +37,13 @@ async function* generateInput() {
   }
 }
 
-(async function() {
+(async function () {
   performance.mark('start');
   const keylen = 64;
 
-  for await (const input of generateInput())
+  for await (const input of generateInput()) {
     await piscina.runTask({ input, keylen });
+  }
 
   performance.mark('end');
   performance.measure('start to end', 'start', 'end');

--- a/examples/scrypt/pooled_sync.js
+++ b/examples/scrypt/pooled_sync.js
@@ -5,12 +5,12 @@ const { resolve } = require('path');
 const crypto = require('crypto');
 const { promisify } = require('util');
 const randomFill = promisify(crypto.randomFill);
-const { performance, PerformanceObserver } = require('perf_hooks')
+const { performance, PerformanceObserver } = require('perf_hooks');
 
 const obs = new PerformanceObserver((entries) => {
-  console.log(entries.getEntries()[0].duration)
+  console.log(entries.getEntries()[0].duration);
 });
-obs.observe({ entryTypes: ['measure']});
+obs.observe({ entryTypes: ['measure'] });
 
 const piscina = new Piscina({
   filename: resolve(__dirname, 'scrypt_sync.js')
@@ -28,7 +28,7 @@ process.on('exit', () => {
   console.log('Wait Time Max:', waitTime.max);
 });
 
-async function* generateInput() {
+async function * generateInput () {
   let max = parseInt(process.argv[2] || 10);
   const data = Buffer.allocUnsafe(10);
   while (max-- > 0) {
@@ -36,7 +36,7 @@ async function* generateInput() {
   }
 }
 
-(async function() {
+(async function () {
   performance.mark('start');
   const keylen = 64;
 

--- a/examples/scrypt/scrypt.js
+++ b/examples/scrypt/scrypt.js
@@ -1,3 +1,4 @@
+// eslint-disable no-unused-vars
 'use strict';
 
 const crypto = require('crypto');
@@ -13,9 +14,10 @@ module.exports = async function ({
   N = 16384,
   r = 8,
   p = 1,
-  maxmem = 32 * 1024 * 1024 }) {
-    return (await scrypt(
-      input,
-      await randomFill(salt),
-      keylen)).toString('hex');
+  maxmem = 32 * 1024 * 1024
+}) {
+  return (await scrypt(
+    input,
+    await randomFill(salt),
+    keylen, { N, r, p, maxmem })).toString('hex');
 };

--- a/examples/scrypt/scrypt_sync.js
+++ b/examples/scrypt/scrypt_sync.js
@@ -10,6 +10,10 @@ module.exports = function ({
   N = 16384,
   r = 8,
   p = 1,
-  maxmem = 32 * 1024 * 1024 }) {
-    return scryptSync(input, randomFillSync(salt), keylen).toString('hex');
+  maxmem = 32 * 1024 * 1024
+}) {
+  return scryptSync(input,
+    randomFillSync(salt),
+    keylen,
+    { N, r, p, maxmem }).toString('hex');
 };

--- a/examples/scrypt/unpooled.js
+++ b/examples/scrypt/unpooled.js
@@ -4,16 +4,16 @@ const crypto = require('crypto');
 const { promisify } = require('util');
 const randomFill = promisify(crypto.randomFill);
 const scrypt = promisify(crypto.scrypt);
-const { performance, PerformanceObserver } = require('perf_hooks')
+const { performance, PerformanceObserver } = require('perf_hooks');
 
 const salt = Buffer.allocUnsafe(16);
 
 const obs = new PerformanceObserver((entries) => {
-  console.log(entries.getEntries()[0].duration)
+  console.log(entries.getEntries()[0].duration);
 });
-obs.observe({ entryTypes: ['measure']});
+obs.observe({ entryTypes: ['measure'] });
 
-async function* generateInput() {
+async function * generateInput () {
   let max = parseInt(process.argv[2] || 10);
   const data = Buffer.allocUnsafe(10);
   while (max-- > 0) {
@@ -21,7 +21,7 @@ async function* generateInput() {
   }
 }
 
-(async function() {
+(async function () {
   performance.mark('start');
   const keylen = 64;
 

--- a/examples/scrypt/unpooled_sync.js
+++ b/examples/scrypt/unpooled_sync.js
@@ -4,16 +4,16 @@ const crypto = require('crypto');
 const { promisify } = require('util');
 const { scryptSync, randomFillSync } = crypto;
 const randomFill = promisify(crypto.randomFill);
-const { performance, PerformanceObserver } = require('perf_hooks')
+const { performance, PerformanceObserver } = require('perf_hooks');
 
 const salt = Buffer.allocUnsafe(16);
 
 const obs = new PerformanceObserver((entries) => {
-  console.log(entries.getEntries()[0].duration)
+  console.log(entries.getEntries()[0].duration);
 });
-obs.observe({ entryTypes: ['measure']});
+obs.observe({ entryTypes: ['measure'] });
 
-async function* generateInput() {
+async function * generateInput () {
   let max = parseInt(process.argv[2] || 10);
   const data = Buffer.allocUnsafe(10);
   while (max-- > 0) {
@@ -21,7 +21,7 @@ async function* generateInput() {
   }
 }
 
-(async function() {
+(async function () {
   performance.mark('start');
   const keylen = 64;
 

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -7,7 +7,7 @@ const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js')
 });
 
-(async function() {
+(async function () {
   const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result);  // Prints 10
+  console.log(result); // Prints 10
 })();

--- a/examples/simple_async/index.js
+++ b/examples/simple_async/index.js
@@ -7,7 +7,7 @@ const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js')
 });
 
-(async function() {
+(async function () {
   const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result);  // Prints 10
+  console.log(result); // Prints 10
 })();

--- a/examples/worker_options/index.js
+++ b/examples/worker_options/index.js
@@ -5,13 +5,13 @@ const { resolve } = require('path');
 
 const piscina = new Piscina({
   filename: resolve(__dirname, 'worker.js'),
-  env: { A: '123'},
+  env: { A: '123' },
   argv: ['a', 'b', 'c'],
   execArgv: ['--no-warnings'],
   workerData: 'ABC'
 });
 
-(async function() {
+(async function () {
   const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result);  // Prints 10
+  console.log(result); // Prints 10
 })();

--- a/examples/worker_options/worker.js
+++ b/examples/worker_options/worker.js
@@ -7,7 +7,7 @@ module.exports = ({ a, b }) => {
   console.log(`
 process.argv: ${process.argv.slice(2)}
 process.execArgv: ${process.execArgv}
-process.env: ${format({...process.env})}
+process.env: ${format({ ...process.env })}
 workerData: ${Piscina.workerData}`);
   return a + b;
 };

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "1.1.0",
   "description": "A fast, efficient Node.js Worker Thread Pool implementation",
   "main": "./dist/src/index.js",
-  "exports": "./dist/src/index.js",
+  "exports": {
+    "import": "./dist/esm-wrapper.mjs",
+    "require": "./dist/src/index.js"
+  },
   "types": "./dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && gen-esm-wrapper . dist/esm-wrapper.mjs",
     "lint": "standardx \"**/*.ts\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
     "test-only": "tap",
@@ -33,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "abort-controller": "^3.0.0",
+    "gen-esm-wrapper": "^1.0.0",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",
     "tap": "^14.10.7",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc && gen-esm-wrapper . dist/esm-wrapper.mjs",
-    "lint": "standardx \"**/*.ts\" | snazzy",
+    "lint": "standardx \"**/*.{ts,mjs,js,cjs}\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
     "test-only": "tap",
     "prepack": "npm run build"

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { AbortController } from 'abort-controller';
 import { EventEmitter } from 'events';
 import Piscina from '..';

--- a/test/async-context.ts
+++ b/test/async-context.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { createHook, executionAsyncId } from 'async_hooks';
 import Piscina from '..';
 import { test } from 'tap';

--- a/test/fixtures/esm-export.mjs
+++ b/test/fixtures/esm-export.mjs
@@ -1,0 +1,1 @@
+export default function (code) { return eval(code); };

--- a/test/fixtures/esm-export.mjs
+++ b/test/fixtures/esm-export.mjs
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-eval
 export default function (code) { return eval(code); };

--- a/test/fixtures/eval.js
+++ b/test/fixtures/eval.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-eval
 module.exports = function (code) { return eval(code); };

--- a/test/histogram.ts
+++ b/test/histogram.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';

--- a/test/load-with-esm.ts
+++ b/test/load-with-esm.ts
@@ -1,0 +1,25 @@
+import { test } from 'tap';
+
+const importESM : (specifier : string) => Promise<any> =
+  // eslint-disable-next-line no-eval
+  eval('(specifier) => import(specifier)');
+
+test('Piscina is default export', {
+  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
+}, async ({ is }) => {
+  is((await importESM('piscina')).default, require('../'));
+});
+
+test('Exports match own property names', {
+  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
+}, async ({ strictDeepEquals }) => {
+  // Check that version, workerData, etc. are re-exported.
+  const exported = new Set(Object.getOwnPropertyNames(await importESM('piscina')));
+  const required = new Set(Object.getOwnPropertyNames(require('../')));
+
+  // Remove constructor properties + default export.
+  for (const k of ['prototype', 'length', 'name']) required.delete(k);
+  exported.delete('default');
+
+  strictDeepEquals(exported, required);
+});

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -1,4 +1,3 @@
-'use strict';
 import Piscina from '..';
 import { test } from 'tap';
 

--- a/test/pool-destroy.ts
+++ b/test/pool-destroy.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import { MessageChannel } from 'worker_threads';
 import Piscina from '..';
 import { test } from 'tap';

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -134,3 +134,13 @@ test('filename can be a file:// URL', async ({ is }) => {
   const result = await worker.runTask('42');
   is(result, 42);
 });
+
+test('filename can be a file:// URL to an ESM module', {
+  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
+}, async ({ is }) => {
+  const worker = new Piscina({
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')).href
+  });
+  const result = await worker.runTask('42');
+  is(result, 42);
+});

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -1,6 +1,7 @@
 import Piscina from '..';
 import { test } from 'tap';
 import { version } from '../package.json';
+import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { EventEmitter } from 'events';
 
@@ -124,4 +125,12 @@ test('passing invalid workerData does not work', async ({ throws }) => {
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
     workerData: process.env
   }) as any), /Cannot transfer object of unsupported type./);
+});
+
+test('filename can be a file:// URL', async ({ is }) => {
+  const worker = new Piscina({
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')).href
+  });
+  const result = await worker.runTask('42');
+  is(result, 42);
 });

--- a/test/task-queue.ts
+++ b/test/task-queue.ts
@@ -1,4 +1,3 @@
-'use strict';
 import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';

--- a/test/test-uncaught-exception-from-handler.ts
+++ b/test/test-uncaught-exception-from-handler.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';

--- a/test/thread-count.ts
+++ b/test/thread-count.ts
@@ -1,4 +1,3 @@
-'use strict';
 import Piscina from '..';
 import { cpus } from 'os';
 import { test } from 'tap';


### PR DESCRIPTION
##### Support passing file:// URLs as filenames

This is for better ESM integration, where `import.meta` is a file URL.

##### Add support for ESM task handlers


##### Add ESM wrapper module

Fixes: https://github.com/jasnell/piscina/issues/16
