### PR TITLE
Add stream example

### DIFF
--- a/examples/stream/index.js
+++ b/examples/stream/index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Piscina = require('../../dist/src');
+const { resolve } = require('path');
+const { MessageChannel } = require('worker_threads');
+const PortDuplex = require('./port_duplex');
+const { pipeline, Writable } = require('stream');
+
+const piscina = new Piscina({
+  filename: resolve(__dirname, 'worker.js')
+});
+
+class W extends Writable {
+  length = 0;
+  _write (chunk, encoding, callback) {
+    this.length += chunk.length;
+    callback();
+  }
+};
+
+(async function () {
+  const channel = new MessageChannel();
+  const duplex = new PortDuplex(channel.port2, { writable: false });
+  const w = new W();
+
+  duplex.on('close', () => channel.port2.close());
+
+  pipeline(duplex, w, () => console.log(w.length));
+
+  await piscina.runTask({ port: channel.port1 }, [channel.port1]);
+})();

--- a/examples/stream/port_duplex.js
+++ b/examples/stream/port_duplex.js
@@ -25,7 +25,7 @@ class PortDuplex extends Duplex {
     // Chunk should always be a buffer here
     const temp = new Uint8Array(chunk);
     // TODO(@jasnell): This will need backpressure implemented
-    this.#port.postMessage(temp);
+    this.#port.postMessage(temp, [temp.buffer]);
     callback();
   }
 

--- a/examples/stream/port_duplex.js
+++ b/examples/stream/port_duplex.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { Duplex } = require('stream');
+
+class PortDuplex extends Duplex {
+  #port = undefined;
+  #transfer = false;
+
+  constructor (port, options) {
+    const {
+      readable = true,
+      writable = true,
+      transfer = false
+    } = { ...options };
+    if (typeof readable !== 'boolean') {
+      throw new TypeError('readable must be a boolean');
+    }
+    if (typeof writable !== 'boolean') {
+      throw new TypeError('writable must be a boolean');
+    }
+    if (typeof transfer !== 'boolean') {
+      throw new TypeError('transfer must be a boolean');
+    }
+    super({ autoDestroy: true, readable, writable });
+    this.#port = port;
+    this.#transfer = transfer;
+    this.#port.onmessage = PortDuplex.#onmessage.bind(this);
+  }
+
+  _write (chunk, encoding, callback) {
+    if (typeof chunk === 'string') {
+      chunk = Buffer.from(chunk, encoding);
+    }
+    const transferList = this.#transfer ? [chunk.buffer] : undefined;
+    this.#port.postMessage(chunk, transferList);
+    callback();
+  }
+
+  _read () {
+    // Do nothing here. A more complete example would
+    // implement proper read/pause behavior.
+  }
+
+  _destroy (err, callback) {
+    if (err) {
+      // TODO(@jasnell): A more complete example would
+      // handle this error more appropriately.
+      this.#port.close();
+      console.error(err);
+      return;
+    }
+    if (this.writableEnded) {
+      this.#port.postMessage(null);
+    }
+    callback();
+  }
+
+  static #onmessage = function ({ data }) {
+    if (data != null) {
+      this.push(data);
+    } else {
+      this.push(null);
+    }
+  };
+}
+
+module.exports = PortDuplex;

--- a/examples/stream/worker.js
+++ b/examples/stream/worker.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const PortDuplex = require('./port_duplex');
+const { createReadStream } = require('fs');
+const { pipeline } = require('stream');
+const { createGzip } = require('zlib');
+
+module.exports = ({ port }) => {
+  return new Promise((resolve, reject) => {
+    const input = createReadStream(__filename);
+    const stream = new PortDuplex(port, { readable: false });
+    pipeline(input, createGzip(), stream, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+};


### PR DESCRIPTION
@addaleax @mcollina ... here's a super simple example of how streams can be supported.

@addaleax ... interestingly, this example hits an Abort inside Node.js when we replace `createBrotliCompress` with `createGzip` or `createDeflate` within the worker.js...

```
james@ubuntu:~/nearform/piscina/examples/stream$ node index
node[30456]: ../src/node_zlib.cc:323:static void node::{anonymous}::CompressionStream<CompressionContext>::Write(const v8::FunctionCallbackInfo<v8::Value>&) [with bool async = true; CompressionContext = node::{anonymous}::ZlibContext]: Assertion `Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf))' failed.
 1: 0xa295b0 node::Abort() [node]
 2: 0xa2962e  [node]
 3: 0xae6b1a  [node]
 4: 0xc0251b  [node]
 5: 0xc03ac6  [node]
 6: 0xc04146 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
2
 7: 0x13a5919  [node]
Aborted (core dumped)
```

The reason, for the abort, as far as I can see, is the fact that the `PortDuplex` transfers ownership of the buffer chunk over to the main thread using a transferList, which highlights a significant grey areas with the Streams API ... when using a Writable, and passing a `Buffer`, who takes ownership responsibility for that Buffer? The caller or the receiver? I don't think we have a clear answer for that but we definitely need a fix that does not trigger an Abort.