### PR TITLE
Emit events on Piscina instance via AsyncResource

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "eventemitter-asyncresource": "^1.0.0",
     "hdr-histogram-js": "^1.2.0",
     "hdr-histogram-percentiles-obj": "^2.0.1"
   },


### PR DESCRIPTION
Previously, it would have looked like the events were triggered by
individual `MessagePort`s, which in turn were potentially created
by other `MessagePort`s, etc.

This makes the `'drain'` and `'error'` events appear in the “flat”
context of the `Piscina` pool creation itself.