### PR TITLE
Implement maxQueue = 'auto'

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ const Pool = require('../..');
 
 const pool = new Pool({
   filename: resolve(__dirname, 'worker.js'),
-  maxQueue: 8
+  maxQueue: 'auto'
 });
 
 const stream = getStreamSomehow();
@@ -170,7 +170,7 @@ pool.on('drain', () => {
 stream
   .on('data', (data) => {
     pool.runTask(data);
-    if (pool.queueSize === maxQueue) {
+    if (pool.queueSize === pool.options.maxQueue) {
       console.log('pausing...', counter, pool.queueSize);
       stream.pause();
     }
@@ -214,9 +214,12 @@ This class extends [`EventEmitter`][] from Node.js.
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
     shut down. By default, this is immediate.
-  * `maxQueue`: (`number`) The maximum number of tasks that may be scheduled
-    to run, but not yet running due to lack of available threads, at a given
-    time. By default, there is no limit.
+  * `maxQueue`: (`number` | `string`) The maximum number of tasks that may be
+    scheduled to run, but not yet running due to lack of available threads, at
+    a given time. By default, there is no limit. The special value `'auto'`
+    may be used to have Piscina calculate the maximum as the square of `maxThreads`.
+    When `'auto'` is used, the calculated `maxQueue` value may be found by checking
+    the [`options.maxQueue`](#property-options-readonly) property.
   * `concurrentTasksPerWorker`: (`number`) Specifies how many tasks can share
     a single Worker thread simultaneously. The default is `1`. This generally
     only makes sense to specify if there is some kind of asynchronous component

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ interface Options {
   minThreads? : number,
   maxThreads? : number,
   idleTimeout? : number,
-  maxQueue? : number,
+  maxQueue? : number | 'auto',
   concurrentTasksPerWorker? : number,
   useAtomics? : boolean,
   resourceLimits? : ResourceLimits,
@@ -69,7 +69,7 @@ interface FilledOptions extends Options {
   minThreads : number,
   maxThreads : number,
   idleTimeout : number,
-  maxQueue : number,
+  maxQueue : number | 'auto',
   concurrentTasksPerWorker : number,
   useAtomics: boolean
 }
@@ -285,6 +285,9 @@ class ThreadPool {
     if (options.minThreads !== undefined &&
         this.options.maxThreads <= options.minThreads) {
       this.options.maxThreads = options.minThreads;
+    }
+    if (options.maxQueue === 'auto') {
+      this.options.maxQueue = this.options.maxThreads ** 2;
     }
 
     this._ensureMinimumWorkers();
@@ -575,6 +578,7 @@ class Piscina extends EventEmitterAsyncResource {
       throw new TypeError('options.idleTimeout must be a non-negative integer');
     }
     if (options.maxQueue !== undefined &&
+        options.maxQueue !== 'auto' &&
         (typeof options.maxQueue !== 'number' || options.maxQueue < 0)) {
       throw new TypeError('options.maxQueue must be a non-negative integer');
     }

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -55,7 +55,7 @@ test('idleTimeout must be non-negative integer', async ({ throws }) => {
   }) as any), /options.idleTimeout must be a non-negative integer/);
 });
 
-test('maxQueue must be non-negative integer', async ({ throws }) => {
+test('maxQueue must be non-negative integer', async ({ throws, is }) => {
   throws(() => new Piscina(({
     maxQueue: -1
   }) as any), /options.maxQueue must be a non-negative integer/);
@@ -63,6 +63,9 @@ test('maxQueue must be non-negative integer', async ({ throws }) => {
   throws(() => new Piscina(({
     maxQueue: 'string'
   }) as any), /options.maxQueue must be a non-negative integer/);
+
+  const p = new Piscina({ maxQueue: 'auto', maxThreads: 2 });
+  is(p.options.maxQueue, 4);
 });
 
 test('useAtomics must be a boolean', async ({ throws }) => {


### PR DESCRIPTION
Special value for `maxQueue` to have the maximum queue limit
autocalculated as a multiple of `maxThreads`.

Fixes: https://github.com/jasnell/piscina/issues/49