### PR TITLE
Wait for Workers to be ready before considering them as task candidates

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -9,5 +9,5 @@ no-browser: true
 test-env: TS_NODE_PROJECT=test/tsconfig.json
 test-ignore: $.
 test-regex: ((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|[jt]sx?)$
-timeout: 30
+timeout: 60
 ts: true

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,6 +13,10 @@ export interface RequestMessage {
   filename: string;
 }
 
+export interface ReadyMessage {
+  ready: true
+};
+
 export interface ResponseMessage {
   taskId : number;
   result : any;

--- a/test/fixtures/wait-for-others.ts
+++ b/test/fixtures/wait-for-others.ts
@@ -1,0 +1,11 @@
+import { threadId } from 'worker_threads';
+
+module.exports = async function ([i32array, n]) {
+  Atomics.add(i32array, 0, 1);
+  Atomics.notify(i32array, 0, Infinity);
+  let lastSeenValue;
+  while ((lastSeenValue = Atomics.load(i32array, 0)) < n) {
+    Atomics.wait(i32array, 0, lastSeenValue);
+  }
+  return threadId;
+};

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -24,8 +24,8 @@ test('idle timeout will let go of threads early', async ({ is }) => {
   // The busy loops are here to prevent one task accidentally finishing before
   // the other and the two of them sharing a thread.
   const firstTasks = [
-    pool.runTask(busyLoop(100) + getThreadId),
-    pool.runTask(busyLoop(100) + getThreadId)
+    pool.runTask(busyLoop(500) + getThreadId),
+    pool.runTask(busyLoop(500) + getThreadId)
   ];
   is(pool.threads.length, 2);
 
@@ -36,8 +36,8 @@ test('idle timeout will let go of threads early', async ({ is }) => {
   is(pool.threads.length, 1);
 
   const secondTasks = [
-    pool.runTask(busyLoop(100) + getThreadId),
-    pool.runTask(busyLoop(100) + getThreadId)
+    pool.runTask(busyLoop(500) + getThreadId),
+    pool.runTask(busyLoop(500) + getThreadId)
   ];
   is(pool.threads.length, 2);
 

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -2,42 +2,35 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 import { promisify } from 'util';
-import { once } from 'events';
 
-const getThreadId = 'require("worker_threads").threadId';
-const busyLoop = (ms : number) =>
-  `{const start = Date.now(); while(Date.now() - start < ${ms}) {}}`;
 const delay = promisify(setTimeout);
 
 test('idle timeout will let go of threads early', async ({ is }) => {
   const pool = new Piscina({
-    filename: resolve(__dirname, 'fixtures/eval.js'),
-    idleTimeout: 2000,
+    filename: resolve(__dirname, 'fixtures/wait-for-others.ts'),
+    idleTimeout: 500,
     minThreads: 1,
     maxThreads: 2
   });
 
   is(pool.threads.length, 1);
-  pool.threads[0].ref();
-  await once(pool.threads[0], 'online');
+  const buffer = new Int32Array(new SharedArrayBuffer(4));
 
-  // The busy loops are here to prevent one task accidentally finishing before
-  // the other and the two of them sharing a thread.
   const firstTasks = [
-    pool.runTask(busyLoop(500) + getThreadId),
-    pool.runTask(busyLoop(500) + getThreadId)
+    pool.runTask([buffer, 2]),
+    pool.runTask([buffer, 2])
   ];
   is(pool.threads.length, 2);
 
   const earlyThreadIds = await Promise.all(firstTasks);
   is(pool.threads.length, 2);
 
-  await delay(3000);
+  await delay(2000);
   is(pool.threads.length, 1);
 
   const secondTasks = [
-    pool.runTask(busyLoop(500) + getThreadId),
-    pool.runTask(busyLoop(500) + getThreadId)
+    pool.runTask([buffer, 4]),
+    pool.runTask([buffer, 4])
   ];
   is(pool.threads.length, 2);
 


### PR DESCRIPTION
Refactor the Worker pool management in order to better accommodate the
async nature of how they are started, and use that to wait until the
target module has been loaded before considering the Worker as a
task processing candidate in order to improve performance.

This also includes bugfixes for working around a crash in Node.js core.