### PR TITLE
Wait for stdio streams to drain before reporting task as finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "abort-controller": "^3.0.0",
+    "concat-stream": "^2.0.0",
     "gen-esm-wrapper": "^1.0.0",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -139,6 +139,17 @@ function onMessage (
         result: result,
         error: null
       };
+
+      // If the task used e.g. console.log(), wait for the stream to drain
+      // before potentially entering the `Atomics.wait()` loop, and before
+      // returning the result so that messages will always be printed even
+      // if the process would otherwise be ready to exit.
+      if (process.stdout.writableLength > 0) {
+        await new Promise((resolve) => process.stdout.write('', resolve));
+      }
+      if (process.stderr.writableLength > 0) {
+        await new Promise((resolve) => process.stderr.write('', resolve));
+      }
     } catch (error) {
       response = {
         taskId,

--- a/test/console-log.ts
+++ b/test/console-log.ts
@@ -1,0 +1,17 @@
+import concat from 'concat-stream';
+import { spawn } from 'child_process';
+import { resolve } from 'path';
+import { test } from 'tap';
+
+test('console.log() calls are not blocked by Atomics.wait()', async ({ is }) => {
+  const proc = spawn(process.execPath, [
+    ...process.execArgv, resolve(__dirname, 'fixtures/console-log.ts')
+  ], {
+    stdio: ['inherit', 'pipe', 'inherit']
+  });
+
+  const data = await new Promise((resolve) => {
+    proc.stdout.setEncoding('utf8').pipe(concat(resolve));
+  });
+  is(data, 'A\nB\n');
+});

--- a/test/fixtures/console-log.ts
+++ b/test/fixtures/console-log.ts
@@ -1,0 +1,9 @@
+import Piscina from '../..';
+import { resolve } from 'path';
+
+const pool = new Piscina({
+  filename: resolve(__dirname, 'eval.js'),
+  maxThreads: 1
+});
+
+pool.runTask('console.log("A"); console.log("B");');


### PR DESCRIPTION
stdio in Workers is asynchronous, and often tasks won’t wait for
writes scheduled by them to finish, in particular when using
`console.log(), so let’s do this for them.