### PR TITLE
Account for loadavg when queuing tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ This class extends [`EventEmitter`][] from Node.js.
   * `taskQueue` : (`TaskQueue`) By default, Piscina uses a first-in-first-out
     queue for submitted tasks. The `taskQueue` option can be used to provide an
     alternative implementation. See [Custom Task Queues][] for additional detail.
+  * `cpuLoadAvgThreshold` : (`number`) If set, specifies an average 1-minute
+    CPU load average threshold such that if the current `os.loadavg()` currently
+    exceeds the threshold, new tasks submitted to the pool will be queued. When
+    set, the value *must* be a number between `0.0` and `1.0`. By default, this
+    check is disabled. The average CPU load average is calculated by taking the
+    current 1-minute load average and dividing by the number of CPU cores
+    available. This option has no effect on Windows.
 
 Use caution when setting resource limits. Setting limits that are too low may
 result in the `Piscina` worker threads being unusable.

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const { platform } = require('os');
+const isWindows = platform() === 'win32';
+
+module.exports = {
+  'ignore-class-method': isWindows ? '_acceptableCpuLoad' : undefined
+};

--- a/test/fixtures/sleep.js
+++ b/test/fixtures/sleep.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { promisify } = require('util');
+const sleep = promisify(setTimeout);
+
+const buf = new Uint32Array(new SharedArrayBuffer(4));
+
+module.exports = async ({ time = 100, a }) => {
+  await sleep(time);
+  const ret = Atomics.exchange(buf, 0, a);
+  return ret;
+};

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -101,3 +101,21 @@ test('taskQueue must be a TaskQueue object', async ({ throws }) => {
     taskQueue: { } as any
   }) as any), /options.taskQueue must be a TaskQueue object/);
 });
+
+test('cpuLoadAvgThreshold must be between 0 and 1', async ({ throws }) => {
+  throws(() => new Piscina(({
+    cpuLoadAvgThreshold: 'test'
+  }) as any), /options.cpuLoadAvgThreshold must be a number between 0.0 and 1.0/);
+
+  throws(() => new Piscina(({
+    cpuLoadAvgThreshold: false
+  }) as any), /options.cpuLoadAvgThreshold must be a number between 0.0 and 1.0/);
+
+  throws(() => new Piscina(({
+    cpuLoadAvgThreshold: -1
+  }) as any), /options.cpuLoadAvgThreshold must be a number between 0.0 and 1.0/);
+
+  throws(() => new Piscina(({
+    cpuLoadAvgThreshold: 1.1
+  }) as any), /options.cpuLoadAvgThreshold must be a number between 0.0 and 1.0/);
+});

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -102,7 +102,7 @@ test('Using cpuLoadAvgThreshold works as expected', {
   skip: platform() === 'win32' // os.loadavg() is always 0 on Windows
 }, async ({ is }) => {
   const pool = new Piscina({
-    cpuLoadAvgThreshold: 0.10,
+    cpuLoadAvgThreshold: 0.90,
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 


### PR DESCRIPTION
@addaleax ... please take a look to see if this approach is acceptable.

This adds a new _acceptableCpuLoad() check that is currently only used when submitting a new task. If the function returns false, the task is queued, even if it otherwise would be dispatched. The check is not applied when a worker comes available with the idea that it is always acceptable for a worker to take on a new task, regardless of cpu load, if there are tasks available.

The check is disabled by default (the default `cpuLoadAvgThreshold` is set to `Infinity`), and disabled entirely on Windows since the loadavg there is not calculated.

The threshold must be a number between 0.0 and 1.0, although we might want to remove the upper limit and allow any value to be specified. The reason is because the cpu loadavg could easily regularly exceed the capacity of available CPU cores.

The load average is calculated by taking the 1-min load average and dividing by the number of CPU cores available (e.g. `os.loadavg()[0] / cpus().length` in order to normalize the values. Alternatively, we could eliminate the upper limit on `cpuLoadAvgThreshold` and avoid the division but then users would need to set a threshold that takes the number of CPUs into consideration.

(Marked this as a draft until we're sure this is the way we want to do it)

Fixes: https://github.com/jasnell/piscina/issues/47