### PR TITLE
Make nice-napi an optional peer dependency

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Update NPM
+        run: npm install --global npm@7.0.12
       - name: Install Dependencies
-        run: npm install
+        if: runner.os != 'Linux'
+        run: npm install --omit=peer
+      - name: Install Dependencies Linux
+        if: runner.os == 'Linux'
+        run: npm install --include=peer
       - name: Test
         run: npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,13 +31,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Update NPM
-        run: npm install --global npm@7.0.12
       - name: Install Dependencies
         if: runner.os != 'Linux'
         run: npm install --omit=peer
       - name: Install Dependencies Linux
         if: runner.os == 'Linux'
-        run: npm install --include=peer
+        # Manually installing peer dependencies until NPM v7+ flags start working
+        run: npm install --include=peer && npm i nice-napi@^1.0.2
       - name: Test
         run: npm test

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "abort-controller": "^3.0.0",
     "concat-stream": "^2.0.0",
     "gen-esm-wrapper": "^1.0.6",
-    "nice-napi": "^1.0.2",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",
     "tap": "^14.10.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "abort-controller": "^3.0.0",
     "concat-stream": "^2.0.0",
     "gen-esm-wrapper": "^1.0.6",
+    "nice-napi": "^1.0.2",
     "snazzy": "^8.0.0",
     "standardx": "^5.0.0",
     "tap": "^14.10.7",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,13 @@
     "hdr-histogram-js": "^1.2.0",
     "hdr-histogram-percentiles-obj": "^2.0.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "nice-napi": "^1.0.2"
+  },
+  "peerDependenciesMeta": {
+    "nice-napi": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "rules": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "always"
       ],
       "no-unused-vars": "off",
+      "no-dupe-class-members": "off",
       "@typescript-eslint/no-unused-vars": "error"
     },
     "globals": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,7 +876,12 @@ class Piscina extends EventEmitterAsyncResource {
     this.#pool = new ThreadPool(this, options);
   }
 
-  runTask (task : any, transferList? : TransferList | string | AbortSignalAny, filename? : string | AbortSignalAny, abortSignal? : AbortSignalAny) {
+  runTask (task : any, transferList? : TransferList, filename? : string, abortSignal? : AbortSignalAny) : Promise<any>;
+  runTask (task : any, transferList? : TransferList, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
+  runTask (task : any, transferList? : string, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
+  runTask (task : any, transferList? : AbortSignalAny, filename? : undefined, abortSignal? : undefined) : Promise<any>;
+
+  runTask (task : any, transferList? : any, filename? : any, abortSignal? : any) {
     // If transferList is a string or AbortSignal, shift it.
     if ((typeof transferList === 'object' && !Array.isArray(transferList)) ||
         typeof transferList === 'string') {
@@ -981,7 +986,7 @@ class Piscina extends EventEmitterAsyncResource {
     return Piscina;
   }
 
-  static move (val : Transferable | TransferListItem | ArrayBufferView) {
+  static move (val : Transferable | TransferListItem | ArrayBufferView | ArrayBuffer | MessagePort) {
     if (val != null && typeof val === 'object' && typeof val !== 'function') {
       if (!isTransferable(val)) {
         if ((types as any).isArrayBufferView(val)) {


### PR DESCRIPTION
In order to prevent `nice-napi` package from being installed, we will move it to peerDependency and then set the optional flag to true (only on NPM v6.11 or higher).