### PR TITLE
fix worker.js code block in promise example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The worker may also be an async function or may return a Promise:
 const { promisify } = require('util');
 const sleep = promisify(setTimeout);
 
-module.exports = async ({ a, b } => {
+module.exports = async ({ a, b }) => {
   // Fake some async activity
   await sleep(100);
   return a + b;
-})
+};
 ```
 
 ESM is also supported for both Piscina and workers:


### PR DESCRIPTION
In the current `worker.js` promise example the code block is:

```
const { promisify } = require('util');
const sleep = promisify(setTimeout);

module.exports = async ({ a, b } => {
  // Fake some async activity
  await sleep(100);
  return a + b;
})
```

However, if you try that, you get thie error:

```
/worker.js:4
module.exports = async ({ a, b } => {
                        ^^^^^^^

SyntaxError: Malformed arrow function parameter list
```