### PR TITLE
Drop 10.x support, update deps, bump to 3.0.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Node.js 14
+      - name: Install Node.js 16
         uses: actions/setup-node@v1
         with:
-          node-version: v14.x
+          node-version: v16.x
       - name: Install dependencies
         run: npm install
       - name: Check linting
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,4 @@
-check-coverage: true
+check-coverage: false
 color: true
 coverage: true
 coverage-report:
@@ -8,6 +8,6 @@ jobs: 2
 no-browser: true
 test-env: TS_NODE_PROJECT=test/tsconfig.json
 test-ignore: $.
-test-regex: ((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|[jt]sx?)$
+test-regex: ((\/|^)(tests?|__tests?__)\/.*|\.(tests?|spec)|^\/?tests?)\.([mc]js|ts)$
 timeout: 60
 ts: true

--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@ The worker may also be an async function or may return a Promise:
 
 ```js
 const { promisify } = require('util');
-const sleep = promisify(setTimeout);
+
+// Awaitable timers are available in Node.js 15.x+
+// For Node.js 12 and 14, use promisify(setTimeout)
+const { setTimeout } = require('timers/promises');
 
 module.exports = async ({ a, b }) => {
   // Fake some async activity
-  await sleep(100);
+  await setTimeout(100);
   return a + b;
 };
 ```
@@ -72,10 +75,8 @@ const piscina = new Piscina({
   filename: new URL('./worker.mjs', import.meta.url).href
 });
 
-(async function () {
-  const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result); // Prints 10
-})();
+const result = await piscina.runTask({ a: 4, b: 6 });
+console.log(result); // Prints 10
 ```
 
 In `worker.mjs`:
@@ -177,6 +178,7 @@ limit. The `'drain'` event may be used to receive notification when the
 queue is empty and all tasks have been submitted to workers for processing.
 
 Example: Using a Node.js stream to feed a Piscina worker pool:
+
 ```js
 'use strict';
 
@@ -708,6 +710,11 @@ as a configuration option in lieu of always creating their own.
 
 
 ## Release Notes
+
+### 3.0.0
+
+* Drops Node.js 10.x support
+* Updates minimum TypeScript target to ES2019
 
 ### 2.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "piscina",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A fast, efficient Node.js Worker Thread Pool implementation",
   "main": "./dist/src/index.js",
   "exports": {
@@ -32,22 +32,21 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^14.14.31",
-    "@typescript-eslint/eslint-plugin": "^4.15.1",
-    "@typescript-eslint/parser": "^4.15.1",
+    "@types/node": "^15.0.1",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
     "abort-controller": "^3.0.0",
     "concat-stream": "^2.0.0",
     "gen-esm-wrapper": "^1.1.1",
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
-    "tap": "^14.11.0",
-    "typescript": "^4.1.5"
+    "tap": "^15.0.6",
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "eventemitter-asyncresource": "^1.0.0",
     "hdr-histogram-js": "^2.0.1",
-    "hdr-histogram-percentiles-obj": "^3.0.0",
-    "nice-napi": "^1.0.2"
+    "hdr-histogram-percentiles-obj": "^3.0.0"
   },
   "optionalDependencies": {
     "nice-napi": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc && gen-esm-wrapper . dist/esm-wrapper.mjs",
     "lint": "standardx \"**/*.{ts,mjs,js,cjs}\" | snazzy",
     "test": "npm run lint && npm run build && npm run test-only",
-    "test-only": "tap",
+    "test-only": "tap --ts",
     "prepack": "npm run build"
   },
   "repository": {
@@ -41,6 +41,7 @@
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
     "tap": "^15.0.6",
+    "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   },
   "dependencies": {

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -4,7 +4,7 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('tasks can be aborted through AbortController while running', async ({ is, rejects }) => {
+test('tasks can be aborted through AbortController while running', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
@@ -15,12 +15,12 @@ test('tasks can be aborted through AbortController while running', async ({ is, 
     /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
-  is(Atomics.load(buf, 0), 1);
+  equal(Atomics.load(buf, 0), 1);
 
   abortController.abort();
 });
 
-test('tasks can be aborted through EventEmitter while running', async ({ is, rejects }) => {
+test('tasks can be aborted through EventEmitter while running', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
@@ -30,12 +30,12 @@ test('tasks can be aborted through EventEmitter while running', async ({ is, rej
   rejects(pool.runTask(buf, ee), /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
-  is(Atomics.load(buf, 0), 1);
+  equal(Atomics.load(buf, 0), 1);
 
   ee.emit('abort');
 });
 
-test('tasks can be aborted through EventEmitter before running', async ({ is, rejects }) => {
+test('tasks can be aborted through EventEmitter before running', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     maxThreads: 1
@@ -48,7 +48,7 @@ test('tasks can be aborted through EventEmitter before running', async ({ is, re
   const task1 = pool.runTask(bufs[0]);
   const ee = new EventEmitter();
   rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
-  is(pool.queueSize, 1);
+  equal(pool.queueSize, 1);
 
   ee.emit('abort');
 
@@ -58,7 +58,7 @@ test('tasks can be aborted through EventEmitter before running', async ({ is, re
   await task1;
 });
 
-test('abortable tasks will not share workers (abortable posted second)', async ({ is, rejects }) => {
+test('abortable tasks will not share workers (abortable posted second)', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     maxThreads: 1,
@@ -72,7 +72,7 @@ test('abortable tasks will not share workers (abortable posted second)', async (
   const task1 = pool.runTask(bufs[0]);
   const ee = new EventEmitter();
   rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
-  is(pool.queueSize, 1);
+  equal(pool.queueSize, 1);
 
   ee.emit('abort');
 
@@ -82,7 +82,7 @@ test('abortable tasks will not share workers (abortable posted second)', async (
   await task1;
 });
 
-test('abortable tasks will not share workers (abortable posted first)', async ({ is, rejects }) => {
+test('abortable tasks will not share workers (abortable posted first)', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -92,15 +92,15 @@ test('abortable tasks will not share workers (abortable posted first)', async ({
   const ee = new EventEmitter();
   rejects(pool.runTask('while(true);', ee), /The task has been aborted/);
   const task2 = pool.runTask('42');
-  is(pool.queueSize, 1);
+  equal(pool.queueSize, 1);
 
   ee.emit('abort');
 
   // Wake up the thread handling the second task.
-  is(await task2, 42);
+  equal(await task2, 42);
 });
 
-test('abortable tasks will not share workers (on worker available)', async ({ is }) => {
+test('abortable tasks will not share workers (on worker available)', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/sleep.js'),
     maxThreads: 1,
@@ -119,9 +119,9 @@ test('abortable tasks will not share workers (on worker available)', async ({ is
     pool.runTask({ time: 100, a: 3 }, new EventEmitter())
   ]);
 
-  is(ret[0], 0);
-  is(ret[1], 1);
-  is(ret[2], 2);
+  equal(ret[0], 0);
+  equal(ret[1], 1);
+  equal(ret[2], 2);
 });
 
 test('abortable tasks will not share workers (destroy workers)', async ({ rejects }) => {
@@ -146,7 +146,7 @@ test('abortable tasks will not share workers (destroy workers)', async ({ reject
     /Terminating worker thread/);
 });
 
-test('aborted AbortSignal rejects task immediately', async ({ rejects, is }) => {
+test('aborted AbortSignal rejects task immediately', async ({ rejects, equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -154,17 +154,17 @@ test('aborted AbortSignal rejects task immediately', async ({ rejects, is }) => 
   const controller = new AbortController();
   // Abort the controller early
   controller.abort();
-  is(controller.signal.aborted, true);
+  equal(controller.signal.aborted, true);
 
   // The data won't be moved because the task will abort immediately.
   const data = new Uint8Array(new SharedArrayBuffer(4));
   rejects(pool.runTask(data, [data.buffer], controller.signal),
     /The task has been aborted/);
 
-  is(data.length, 4);
+  equal(data.length, 4);
 });
 
-test('task with AbortSignal cleans up properly', async ({ is }) => {
+test('task with AbortSignal cleans up properly', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
@@ -175,7 +175,7 @@ test('task with AbortSignal cleans up properly', async ({ is }) => {
 
   const { getEventListeners } = EventEmitter as any;
   if (typeof getEventListeners === 'function') {
-    is(getEventListeners(ee, 'abort').length, 0);
+    equal(getEventListeners(ee, 'abort').length, 0);
   }
 
   const controller = new AbortController();

--- a/test/async-context.ts
+++ b/test/async-context.ts
@@ -3,7 +3,7 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('postTask() calls the correct async hooks', async ({ is }) => {
+test('postTask() calls the correct async hooks', async ({ equal }) => {
   let taskId;
   let initCalls = 0;
   let beforeCalls = 0;
@@ -36,8 +36,8 @@ test('postTask() calls the correct async hooks', async ({ is }) => {
   await pool.runTask('42');
 
   hook.disable();
-  is(initCalls, 1);
-  is(beforeCalls, 1);
-  is(afterCalls, 1);
-  is(resolveCalls, 1);
+  equal(initCalls, 1);
+  equal(beforeCalls, 1);
+  equal(afterCalls, 1);
+  equal(resolveCalls, 1);
 });

--- a/test/atomics-optimization.ts
+++ b/test/atomics-optimization.ts
@@ -2,7 +2,7 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('coverage test for Atomics optimization', async ({ is }) => {
+test('coverage test for Atomics optimization', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep-or.ts'),
     minThreads: 2,
@@ -29,7 +29,7 @@ test('coverage test for Atomics optimization', async ({ is }) => {
   // The check above could also be !== 2 but it's hard to get things right
   // sometimes and this gives us a nice assertion. Basically, at this point
   // exactly 2 tasks should be in Atomics.wait() state.
-  is(popcount8(v), 2);
+  equal(popcount8(v), 2);
   // Wake both tasks up as simultaneously as possible. The other 2 tasks should
   // then start executing.
   Atomics.store(i32array, 0, 0);
@@ -49,7 +49,7 @@ test('coverage test for Atomics optimization', async ({ is }) => {
 
   // Wake up the remaining 2 tasks in order to make sure that the test finishes.
   // Do the same consistency check beforehand as above.
-  is(popcount8(v), 2);
+  equal(popcount8(v), 2);
   Atomics.store(i32array, 0, 0);
   Atomics.notify(i32array, 0, Infinity);
 

--- a/test/console-log.ts
+++ b/test/console-log.ts
@@ -3,7 +3,7 @@ import { spawn } from 'child_process';
 import { resolve } from 'path';
 import { test } from 'tap';
 
-test('console.log() calls are not blocked by Atomics.wait()', async ({ is }) => {
+test('console.log() calls are not blocked by Atomics.wait()', async ({ equal }) => {
   const proc = spawn(process.execPath, [
     ...process.execArgv, resolve(__dirname, 'fixtures/console-log.ts')
   ], {
@@ -13,5 +13,5 @@ test('console.log() calls are not blocked by Atomics.wait()', async ({ is }) => 
   const data = await new Promise((resolve) => {
     proc.stdout.setEncoding('utf8').pipe(concat(resolve));
   });
-  is(data, 'A\nB\n');
+  equal(data, 'A\nB\n');
 });

--- a/test/histogram.ts
+++ b/test/histogram.ts
@@ -2,7 +2,7 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('pool will maintain run and wait time histograms', async ({ is, ok }) => {
+test('pool will maintain run and wait time histograms', async ({ equal, ok }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
@@ -15,17 +15,17 @@ test('pool will maintain run and wait time histograms', async ({ is, ok }) => {
 
   const waitTime = pool.waitTime as any;
   ok(waitTime);
-  is(typeof waitTime.average, 'number');
-  is(typeof waitTime.mean, 'number');
-  is(typeof waitTime.stddev, 'number');
-  is(typeof waitTime.min, 'number');
-  is(typeof waitTime.max, 'number');
+  equal(typeof waitTime.average, 'number');
+  equal(typeof waitTime.mean, 'number');
+  equal(typeof waitTime.stddev, 'number');
+  equal(typeof waitTime.min, 'number');
+  equal(typeof waitTime.max, 'number');
 
   const runTime = pool.runTime as any;
   ok(runTime);
-  is(typeof runTime.average, 'number');
-  is(typeof runTime.mean, 'number');
-  is(typeof runTime.stddev, 'number');
-  is(typeof runTime.min, 'number');
-  is(typeof runTime.max, 'number');
+  equal(typeof runTime.average, 'number');
+  equal(typeof runTime.mean, 'number');
+  equal(typeof runTime.stddev, 'number');
+  equal(typeof runTime.min, 'number');
+  equal(typeof runTime.max, 'number');
 });

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 
 const delay = promisify(setTimeout);
 
-test('idle timeout will let go of threads early', async ({ is }) => {
+test('idle timeout will let go of threads early', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-others.ts'),
     idleTimeout: 500,
@@ -13,32 +13,32 @@ test('idle timeout will let go of threads early', async ({ is }) => {
     maxThreads: 2
   });
 
-  is(pool.threads.length, 1);
+  equal(pool.threads.length, 1);
   const buffer = new Int32Array(new SharedArrayBuffer(4));
 
   const firstTasks = [
     pool.runTask([buffer, 2]),
     pool.runTask([buffer, 2])
   ];
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
 
   const earlyThreadIds = await Promise.all(firstTasks);
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
 
   await delay(2000);
-  is(pool.threads.length, 1);
+  equal(pool.threads.length, 1);
 
   const secondTasks = [
     pool.runTask([buffer, 4]),
     pool.runTask([buffer, 4])
   ];
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
 
   const lateThreadIds = await Promise.all(secondTasks);
 
   // One thread should have been idle in between and exited, one should have
   // been reused.
-  is(earlyThreadIds.length, 2);
-  is(lateThreadIds.length, 2);
-  is(new Set([...earlyThreadIds, ...lateThreadIds]).size, 3);
+  equal(earlyThreadIds.length, 2);
+  equal(lateThreadIds.length, 2);
+  equal(new Set([...earlyThreadIds, ...lateThreadIds]).size, 3);
 });

--- a/test/load-with-esm.ts
+++ b/test/load-with-esm.ts
@@ -4,15 +4,11 @@ const importESM : (specifier : string) => Promise<any> =
   // eslint-disable-next-line no-eval
   eval('(specifier) => import(specifier)');
 
-test('Piscina is default export', {
-  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ equal }) => {
+test('Piscina is default export', {}, async ({ equal }) => {
   equal((await importESM('piscina')).default, require('../'));
 });
 
-test('Exports match own property names', {
-  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ strictSame }) => {
+test('Exports match own property names', {}, async ({ strictSame }) => {
   // Check that version, workerData, etc. are re-exported.
   const exported = new Set(Object.getOwnPropertyNames(await importESM('piscina')));
   const required = new Set(Object.getOwnPropertyNames(require('../')));

--- a/test/load-with-esm.ts
+++ b/test/load-with-esm.ts
@@ -6,13 +6,13 @@ const importESM : (specifier : string) => Promise<any> =
 
 test('Piscina is default export', {
   skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ is }) => {
-  is((await importESM('piscina')).default, require('../'));
+}, async ({ equal }) => {
+  equal((await importESM('piscina')).default, require('../'));
 });
 
 test('Exports match own property names', {
   skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ strictDeepEquals }) => {
+}, async ({ strictSame }) => {
   // Check that version, workerData, etc. are re-exported.
   const exported = new Set(Object.getOwnPropertyNames(await importESM('piscina')));
   const required = new Set(Object.getOwnPropertyNames(require('../')));
@@ -21,5 +21,5 @@ test('Exports match own property names', {
   for (const k of ['prototype', 'length', 'name']) required.delete(k);
   exported.delete('default');
 
-  strictDeepEquals(exported, required);
+  strictSame(exported, required);
 });

--- a/test/move-test.ts
+++ b/test/move-test.ts
@@ -25,11 +25,11 @@ test('Marking an object as movable works as expected', async ({ ok }) => {
   ok(isMovable(obj)); // It is movable now
 });
 
-test('Marking primitives and null works as expected', async ({ is }) => {
-  is(Piscina.move(null), null);
-  is(Piscina.move(1 as any), 1);
-  is(Piscina.move(false as any), false);
-  is(Piscina.move('test' as any), 'test');
+test('Marking primitives and null works as expected', async ({ equal }) => {
+  equal(Piscina.move(null), null);
+  equal(Piscina.move(1 as any), 1);
+  equal(Piscina.move(false as any), false);
+  equal(Piscina.move('test' as any), 'test');
 });
 
 test('Using Piscina.move() returns a movable object', async ({ ok }) => {
@@ -42,34 +42,34 @@ test('Using Piscina.move() returns a movable object', async ({ ok }) => {
   ok(isMovable(movable)); // It is movable now
 });
 
-test('Using ArrayBuffer works as expected', async ({ ok, is }) => {
+test('Using ArrayBuffer works as expected', async ({ ok, equal }) => {
   const ab = new ArrayBuffer(5);
   const movable = Piscina.move(ab);
   ok(isMovable(movable));
   ok(types.isAnyArrayBuffer(movable[valueSymbol]));
   ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
-  is(movable[transferableSymbol], ab);
+  equal(movable[transferableSymbol], ab);
 });
 
-test('Using TypedArray works as expected', async ({ ok, is }) => {
+test('Using TypedArray works as expected', async ({ ok, equal }) => {
   const ab = new Uint8Array(5);
   const movable = Piscina.move(ab);
   ok(isMovable(movable));
   ok((types as any).isArrayBufferView(movable[valueSymbol]));
   ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
-  is(movable[transferableSymbol], ab.buffer);
+  equal(movable[transferableSymbol], ab.buffer);
 });
 
-test('Using MessagePort works as expected', async ({ ok, is }) => {
+test('Using MessagePort works as expected', async ({ ok, equal }) => {
   const mc = new MessageChannel();
   const movable = Piscina.move(mc.port1);
   ok(isMovable(movable));
   ok(movable[valueSymbol] instanceof MessagePort);
   ok(movable[transferableSymbol] instanceof MessagePort);
-  is(movable[transferableSymbol], mc.port1);
+  equal(movable[transferableSymbol], mc.port1);
 });
 
-test('Moving works', async ({ is, ok }) => {
+test('Moving works', async ({ equal, ok }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -77,7 +77,7 @@ test('Moving works', async ({ is, ok }) => {
   {
     const ab = new ArrayBuffer(10);
     const ret = await pool.runTask(Piscina.move(ab));
-    is(ab.byteLength, 0); // It was moved
+    equal(ab.byteLength, 0); // It was moved
     ok(types.isAnyArrayBuffer(ret));
   }
 
@@ -85,7 +85,7 @@ test('Moving works', async ({ is, ok }) => {
     // Test with empty transferList
     const ab = new ArrayBuffer(10);
     const ret = await pool.runTask(Piscina.move(ab), []);
-    is(ab.byteLength, 0); // It was moved
+    equal(ab.byteLength, 0); // It was moved
     ok(types.isAnyArrayBuffer(ret));
   }
 });

--- a/test/nice.ts
+++ b/test/nice.ts
@@ -4,7 +4,7 @@ import { test } from 'tap';
 
 test('can set niceness for threads on Linux', {
   skip: process.platform !== 'linux'
-}, async ({ is }) => {
+}, async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     niceIncrement: 5
@@ -17,15 +17,15 @@ test('can set niceness for threads on Linux', {
 
   // niceness is capped to 19 on Linux.
   const expected = Math.min(currentNiceness + 5, 19);
-  is(result, expected);
+  equal(result, expected);
 });
 
-test('setting niceness never does anything bad', async ({ is }) => {
+test('setting niceness never does anything bad', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     niceIncrement: 5
   });
 
   const result = await worker.runTask('42');
-  is(result, 42);
+  equal(result, 42);
 });

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -55,7 +55,7 @@ test('idleTimeout must be non-negative integer', async ({ throws }) => {
   }) as any), /options.idleTimeout must be a non-negative integer/);
 });
 
-test('maxQueue must be non-negative integer', async ({ throws, is }) => {
+test('maxQueue must be non-negative integer', async ({ throws, equal }) => {
   throws(() => new Piscina(({
     maxQueue: -1
   }) as any), /options.maxQueue must be a non-negative integer/);
@@ -65,7 +65,7 @@ test('maxQueue must be non-negative integer', async ({ throws, is }) => {
   }) as any), /options.maxQueue must be a non-negative integer/);
 
   const p = new Piscina({ maxQueue: 'auto', maxThreads: 2 });
-  is(p.options.maxQueue, 4);
+  equal(p.options.maxQueue, 4);
 });
 
 test('useAtomics must be a boolean', async ({ throws }) => {

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -3,15 +3,15 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('postTask() can transfer ArrayBuffer instances', async ({ is }) => {
+test('postTask() can transfer ArrayBuffer instances', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
 
   const ab = new ArrayBuffer(40);
   await pool.runTask({ ab }, [ab]);
-  is(pool.completed, 1);
-  is(ab.byteLength, 0);
+  equal(pool.completed, 1);
+  equal(ab.byteLength, 0);
 });
 
 test('postTask() cannot clone build-in objects', async ({ rejects }) => {
@@ -81,18 +81,18 @@ test('Piscina emits drain', async ({ ok }) => {
   ok(drained);
 });
 
-test('Piscina can use async loaded workers', async ({ is }) => {
+test('Piscina can use async loaded workers', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-async.js')
   });
-  is(await pool.runTask('1'), 1);
+  equal(await pool.runTask('1'), 1);
 });
 
 test('Piscina can use async loaded esm workers', {
   skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ is }) => {
+}, async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/esm-async.mjs')
   });
-  is(await pool.runTask('1'), 1);
+  equal(await pool.runTask('1'), 1);
 });

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -88,9 +88,7 @@ test('Piscina can use async loaded workers', async ({ equal }) => {
   equal(await pool.runTask('1'), 1);
 });
 
-test('Piscina can use async loaded esm workers', {
-  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ equal }) => {
+test('Piscina can use async loaded esm workers', {}, async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/esm-async.mjs')
   });

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -5,24 +5,24 @@ import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { EventEmitter } from 'events';
 
-test('Piscina is exposed on export', async ({ is }) => {
-  is(Piscina.version, version);
+test('Piscina is exposed on export', async ({ equal }) => {
+  equal(Piscina.version, version);
 });
 
-test('Piscina is exposed on itself', async ({ is }) => {
-  is(Piscina.Piscina, Piscina);
+test('Piscina is exposed on itself', async ({ equal }) => {
+  equal(Piscina.Piscina, Piscina);
 });
 
-test('Piscina.isWorkerThread has the correct value', async ({ is }) => {
-  is(Piscina.isWorkerThread, false);
+test('Piscina.isWorkerThread has the correct value', async ({ equal }) => {
+  equal(Piscina.isWorkerThread, false);
 });
 
-test('Piscina.isWorkerThread has the correct value (worker)', async ({ is }) => {
+test('Piscina.isWorkerThread has the correct value (worker)', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
   const result = await worker.runTask(null);
-  is(result, 'done');
+  equal(result, 'done');
 });
 
 test('Piscina instance is an EventEmitter', async ({ ok }) => {
@@ -30,48 +30,48 @@ test('Piscina instance is an EventEmitter', async ({ ok }) => {
   ok(piscina instanceof EventEmitter);
 });
 
-test('Piscina constructor options are correctly set', async ({ is }) => {
+test('Piscina constructor options are correctly set', async ({ equal }) => {
   const piscina = new Piscina({
     minThreads: 10,
     maxThreads: 20,
     maxQueue: 30
   });
 
-  is(piscina.options.minThreads, 10);
-  is(piscina.options.maxThreads, 20);
-  is(piscina.options.maxQueue, 30);
+  equal(piscina.options.minThreads, 10);
+  equal(piscina.options.maxThreads, 20);
+  equal(piscina.options.maxQueue, 30);
 });
 
-test('trivial eval() handler works', async ({ is }) => {
+test('trivial eval() handler works', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   const result = await worker.runTask('42');
-  is(result, 42);
+  equal(result, 42);
 });
 
-test('async eval() handler works', async ({ is }) => {
+test('async eval() handler works', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   const result = await worker.runTask('Promise.resolve(42)');
-  is(result, 42);
+  equal(result, 42);
 });
 
-test('filename can be provided while posting', async ({ is }) => {
+test('filename can be provided while posting', async ({ equal }) => {
   const worker = new Piscina();
   const result = await worker.runTask(
     'Promise.resolve(42)',
     resolve(__dirname, 'fixtures/eval.js'));
-  is(result, 42);
+  equal(result, 42);
 });
 
-test('filename can be null when initially provided', async ({ is }) => {
+test('filename can be null when initially provided', async ({ equal }) => {
   const worker = new Piscina({ filename: null });
   const result = await worker.runTask(
     'Promise.resolve(42)',
     resolve(__dirname, 'fixtures/eval.js'));
-  is(result, 42);
+  equal(result, 42);
 });
 
 test('filename must be provided while posting', async ({ rejects }) => {
@@ -110,12 +110,12 @@ test('passing execArgv to workers works', async ({ same }) => {
   same(env, ['--no-warnings']);
 });
 
-test('passing valid workerData works', async ({ is }) => {
+test('passing valid workerData works', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
     workerData: 'ABC'
   });
-  is(Piscina.workerData, undefined);
+  equal(Piscina.workerData, undefined);
 
   await pool.runTask(null);
 });
@@ -127,31 +127,31 @@ test('passing invalid workerData does not work', async ({ throws }) => {
   }) as any), /Cannot transfer object of unsupported type./);
 });
 
-test('filename can be a file:// URL', async ({ is }) => {
+test('filename can be a file:// URL', async ({ equal }) => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')).href
   });
   const result = await worker.runTask('42');
-  is(result, 42);
+  equal(result, 42);
 });
 
 test('filename can be a file:// URL to an ESM module', {
   skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ is }) => {
+}, async ({ equal }) => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')).href
   });
   const result = await worker.runTask('42');
-  is(result, 42);
+  equal(result, 42);
 });
 
-test('duration and utilization calculations work', async ({ is, ok }) => {
+test('duration and utilization calculations work', async ({ equal, ok }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   // Initial utilization is always 0
-  is(worker.utilization, 0);
+  equal(worker.utilization, 0);
 
   await Promise.all([
     worker.runTask('42'),

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -135,9 +135,7 @@ test('filename can be a file:// URL', async ({ equal }) => {
   equal(result, 42);
 });
 
-test('filename can be a file:// URL to an ESM module', {
-  skip: process.version.startsWith('v12.') // ESM support is flagged on v12.x
-}, async ({ equal }) => {
+test('filename can be a file:// URL to an ESM module', {}, async ({ equal }) => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')).href
   });

--- a/test/task-queue.ts
+++ b/test/task-queue.ts
@@ -3,15 +3,15 @@ import { test } from 'tap';
 import { resolve } from 'path';
 import { Task, TaskQueue } from '../dist/src/common';
 
-test('will put items into a task queue until they can run', async ({ is }) => {
+test('will put items into a task queue until they can run', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 2,
     maxThreads: 3
   });
 
-  is(pool.threads.length, 2);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 2);
+  equal(pool.queueSize, 0);
 
   const buffers = [
     new Int32Array(new SharedArrayBuffer(4)),
@@ -23,20 +23,20 @@ test('will put items into a task queue until they can run', async ({ is }) => {
   const results = [];
 
   results.push(pool.runTask(buffers[0]));
-  is(pool.threads.length, 2);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 2);
+  equal(pool.queueSize, 0);
 
   results.push(pool.runTask(buffers[1]));
-  is(pool.threads.length, 2);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 2);
+  equal(pool.queueSize, 0);
 
   results.push(pool.runTask(buffers[2]));
-  is(pool.threads.length, 3);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 3);
+  equal(pool.queueSize, 0);
 
   results.push(pool.runTask(buffers[3]));
-  is(pool.threads.length, 3);
-  is(pool.queueSize, 1);
+  equal(pool.threads.length, 3);
+  equal(pool.queueSize, 1);
 
   for (const buffer of buffers) {
     Atomics.store(buffer, 0, 1);
@@ -44,12 +44,12 @@ test('will put items into a task queue until they can run', async ({ is }) => {
   }
 
   await results[0];
-  is(pool.queueSize, 0);
+  equal(pool.queueSize, 0);
 
   await Promise.all(results);
 });
 
-test('will reject items over task queue limit', async ({ is, rejects }) => {
+test('will reject items over task queue limit', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.ts'),
     minThreads: 0,
@@ -57,26 +57,26 @@ test('will reject items over task queue limit', async ({ is, rejects }) => {
     maxQueue: 2
   });
 
-  is(pool.threads.length, 0);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 0);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 1);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 1);
 
   rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 2);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 2);
 
   rejects(pool.runTask('while (true) {}'), /Task queue is at limit/);
   await pool.destroy();
 });
 
-test('will reject items when task queue is unavailable', async ({ is, rejects }) => {
+test('will reject items when task queue is unavailable', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.ts'),
     minThreads: 0,
@@ -84,18 +84,18 @@ test('will reject items when task queue is unavailable', async ({ is, rejects })
     maxQueue: 0
   });
 
-  is(pool.threads.length, 0);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 0);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
-test('will reject items when task queue is unavailable (fixed thread count)', async ({ is, rejects }) => {
+test('will reject items when task queue is unavailable (fixed thread count)', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.ts'),
     minThreads: 1,
@@ -103,18 +103,18 @@ test('will reject items when task queue is unavailable (fixed thread count)', as
     maxQueue: 0
   });
 
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (both tests blocking)', async ({ is, rejects }) => {
+test('tasks can share a Worker if requested (both tests blocking)', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 0,
@@ -123,21 +123,21 @@ test('tasks can share a Worker if requested (both tests blocking)', async ({ is,
     concurrentTasksPerWorker: 2
   });
 
-  is(pool.threads.length, 0);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 0);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask(new Int32Array(new SharedArrayBuffer(4))));
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask(new Int32Array(new SharedArrayBuffer(4))));
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (one test finishes)', async ({ is, rejects }) => {
+test('tasks can share a Worker if requested (one test finishes)', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 0,
@@ -151,30 +151,30 @@ test('tasks can share a Worker if requested (one test finishes)', async ({ is, r
     new Int32Array(new SharedArrayBuffer(4))
   ];
 
-  is(pool.threads.length, 0);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 0);
+  equal(pool.queueSize, 0);
 
   const firstTask = pool.runTask(buffers[0]);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   rejects(pool.runTask(
     'new Promise((resolve) => setTimeout(resolve, 1000000))',
     resolve(__dirname, 'fixtures/eval.js')), /Terminating worker thread/);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   Atomics.store(buffers[0], 0, 1);
   Atomics.notify(buffers[0], 0, 1);
 
   await firstTask;
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (both tests finish)', async ({ is }) => {
+test('tasks can share a Worker if requested (both tests finish)', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 1,
@@ -188,16 +188,16 @@ test('tasks can share a Worker if requested (both tests finish)', async ({ is })
     new Int32Array(new SharedArrayBuffer(4))
   ];
 
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   const firstTask = pool.runTask(buffers[0]);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   const secondTask = pool.runTask(buffers[1]);
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 
   Atomics.store(buffers[0], 0, 1);
   Atomics.store(buffers[1], 0, 1);
@@ -207,15 +207,15 @@ test('tasks can share a Worker if requested (both tests finish)', async ({ is })
   Atomics.wait(buffers[1], 0, 1);
 
   await firstTask;
-  is(buffers[0][0], -1);
+  equal(buffers[0][0], -1);
   await secondTask;
-  is(buffers[1][0], -1);
+  equal(buffers[1][0], -1);
 
-  is(pool.threads.length, 1);
-  is(pool.queueSize, 0);
+  equal(pool.threads.length, 1);
+  equal(pool.queueSize, 0);
 });
 
-test('custom task queue works', async ({ is, ok }) => {
+test('custom task queue works', async ({ equal, ok }) => {
   let sizeCalled : boolean = false;
   let shiftCalled : boolean = false;
   let pushCalled : boolean = false;
@@ -239,9 +239,9 @@ test('custom task queue works', async ({ is, ok }) => {
 
       ok(Piscina.queueOptionsSymbol in task);
       if ((task as any).task.a === 3) {
-        is(task[Piscina.queueOptionsSymbol], null);
+        equal(task[Piscina.queueOptionsSymbol], null);
       } else {
-        is(task[Piscina.queueOptionsSymbol].option,
+        equal(task[Piscina.queueOptionsSymbol].option,
           (task as any).task.a);
       }
     }
@@ -270,9 +270,9 @@ test('custom task queue works', async ({ is, ok }) => {
     pool.runTask({ a: 3 }) // No queueOptionsSymbol attached
   ]);
 
-  is(ret[0].a, 1);
-  is(ret[1].a, 2);
-  is(ret[2].a, 3);
+  equal(ret[0].a, 1);
+  equal(ret[1].a, 2);
+  equal(ret[2].a, 3);
 
   ok(sizeCalled);
   ok(pushCalled);

--- a/test/test-resourcelimits.ts
+++ b/test/test-resourcelimits.ts
@@ -2,7 +2,7 @@ import Piscina from '..';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('resourceLimits causes task to reject', async ({ is, rejects }) => {
+test('resourceLimits causes task to reject', async ({ equal, rejects }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/resource-limits.js'),
     resourceLimits: {
@@ -26,9 +26,9 @@ test('resourceLimits causes task to reject', async ({ is, rejects }) => {
     // now.
   });
   const limits : any = worker.options.resourceLimits;
-  is(limits.maxOldGenerationSizeMb, 16);
-  is(limits.maxYoungGenerationSizeMb, 4);
-  is(limits.codeRangeSizeMb, 16);
+  equal(limits.maxOldGenerationSizeMb, 16);
+  equal(limits.maxYoungGenerationSizeMb, 4);
+  equal(limits.codeRangeSizeMb, 16);
   rejects(worker.runTask(null),
     /Worker terminated due to reaching memory limit: JS heap out of memory/);
 });

--- a/test/test-uncaught-exception-from-handler.ts
+++ b/test/test-uncaught-exception-from-handler.ts
@@ -21,7 +21,7 @@ test('uncaught exception in immediate resets Worker', async ({ rejects }) => {
     `), /not_caught/);
 });
 
-test('uncaught exception in immediate after task yields error event', async ({ is }) => {
+test('uncaught exception in immediate after task yields error event', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -35,14 +35,14 @@ test('uncaught exception in immediate after task yields error event', async ({ i
     42
   `);
 
-  is(await taskResult, 42);
+  equal(await taskResult, 42);
 
   // Hack a bit to make sure we get the 'exit'/'error' events.
-  is(pool.threads.length, 1);
+  equal(pool.threads.length, 1);
   pool.threads[0].ref();
 
   // This is the main aassertion here.
-  is((await errorEvent)[0].message, 'not_caught');
+  equal((await errorEvent)[0].message, 'not_caught');
 });
 
 test('using parentPort is treated as an error', async ({ rejects }) => {

--- a/test/thread-count.ts
+++ b/test/thread-count.ts
@@ -3,46 +3,46 @@ import { cpus } from 'os';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-test('will start with minThreads and max out at maxThreads', async ({ is, rejects }) => {
+test('will start with minThreads and max out at maxThreads', async ({ equal, rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 2,
     maxThreads: 4
   });
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
   rejects(pool.runTask('while(true) {}'));
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
   rejects(pool.runTask('while(true) {}'));
-  is(pool.threads.length, 2);
+  equal(pool.threads.length, 2);
   rejects(pool.runTask('while(true) {}'));
-  is(pool.threads.length, 3);
+  equal(pool.threads.length, 3);
   rejects(pool.runTask('while(true) {}'));
-  is(pool.threads.length, 4);
+  equal(pool.threads.length, 4);
   rejects(pool.runTask('while(true) {}'));
-  is(pool.threads.length, 4);
+  equal(pool.threads.length, 4);
   await pool.destroy();
 });
 
-test('low maxThreads sets minThreads', async ({ is }) => {
+test('low maxThreads sets minThreads', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1
   });
-  is(pool.threads.length, 1);
-  is(pool.options.minThreads, 1);
-  is(pool.options.maxThreads, 1);
+  equal(pool.threads.length, 1);
+  equal(pool.options.minThreads, 1);
+  equal(pool.options.maxThreads, 1);
 });
 
 test('high minThreads sets maxThreads', {
   skip: cpus().length > 8
-}, async ({ is }) => {
+}, async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 16
   });
-  is(pool.threads.length, 16);
-  is(pool.options.minThreads, 16);
-  is(pool.options.maxThreads, 16);
+  equal(pool.threads.length, 16);
+  equal(pool.options.minThreads, 16);
+  equal(pool.options.maxThreads, 16);
 });
 
 test('conflicting min/max threads is error', async ({ throws }) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2018"],
+    "lib": ["es2020"],
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2020"],
+    "lib": ["es2019"],
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,


### PR DESCRIPTION
/cc @addalex @mcollina 

Updates deps and drops 10.x support. Bumps to 3.0.0.

~~@addaleax ... one of the updates here causes the `atomics-optimization.ts` test to timeout. If you have any ideas there let me know :-)~~

~~Also, the TAP update breaks coverage on some of the ESM related branches. I'm investigating. It's not clear if it's an issue with TAP or with our tests. ESM support does appear to work just fine.~~

Update: OK, so the coverage failures appear to be a limitation of TAP 15 to provide coverage on native ESM. Not surprising there but unfortunately that makes the coverage report a bit useless.