### PR TITLE
Add Piscina.prototype.run(), deprecate runTask()

### DIFF
--- a/examples/abort/index.js
+++ b/examples/abort/index.js
@@ -11,7 +11,9 @@ const piscina = new Piscina({
 (async function () {
   const abortController = new AbortController();
   try {
-    const task = piscina.runTask({ a: 4, b: 6 }, abortController.signal);
+    const task = piscina.run(
+      { a: 4, b: 6 },
+      { signal: abortController.signal });
     abortController.abort();
     await task;
   } catch (err) {

--- a/examples/abort/index2.js
+++ b/examples/abort/index2.js
@@ -11,7 +11,7 @@ const piscina = new Piscina({
 (async function () {
   const ee = new EventEmitter();
   try {
-    const task = piscina.runTask({ a: 4, b: 6 }, ee);
+    const task = piscina.run({ a: 4, b: 6 }, { signal: ee });
     ee.emit('abort');
     await task;
   } catch (err) {

--- a/examples/abort/index3.js
+++ b/examples/abort/index3.js
@@ -13,7 +13,7 @@ const piscina = new Piscina({
   // Use a timer to limit task processing length
   const t = setTimeout(() => ee.emit('abort'), 500);
   try {
-    await piscina.runTask({ a: 4, b: 6 }, ee);
+    await piscina.run({ a: 4, b: 6 }, { signal: ee });
   } catch (err) {
     console.log('The task timed out');
   } finally {

--- a/examples/abort/index4.js
+++ b/examples/abort/index4.js
@@ -16,7 +16,7 @@ const piscina = new Piscina({
   // Use a timer to limit task processing length
   const t = setTimeout(() => ac.abort(), 500);
   try {
-    await piscina.runTask({ a: 4, b: 6 }, ac.signal);
+    await piscina.run({ a: 4, b: 6 }, { signal: ac.signal });
   } catch (err) {
     console.log('The task timed out');
   } finally {

--- a/examples/async_load/index.js
+++ b/examples/async_load/index.js
@@ -7,7 +7,7 @@ const { resolve } = require('path');
 
 (async () => {
   await Promise.all([
-    pool.runTask({}, resolve(__dirname, 'worker')),
-    pool.runTask({}, resolve(__dirname, 'worker.mjs'))
+    pool.run({}, { filename: resolve(__dirname, 'worker') }),
+    pool.run({}, { filename: resolve(__dirname, 'worker.mjs') })
   ]);
 })();

--- a/examples/es-module/index.mjs
+++ b/examples/es-module/index.mjs
@@ -4,7 +4,5 @@ const piscina = new Piscina({
   filename: new URL('./worker.mjs', import.meta.url).href
 });
 
-(async function () {
-  const result = await piscina.runTask({ a: 4, b: 6 });
-  console.log(result); // Prints 10
-})();
+const result = await piscina.run({ a: 4, b: 6 });
+console.log(result); // Prints 10

--- a/examples/message_port/index.js
+++ b/examples/message_port/index.js
@@ -14,5 +14,5 @@ const piscina = new Piscina({
     console.log(message);
     channel.port2.close();
   });
-  await piscina.runTask({ port: channel.port1 }, [channel.port1]);
+  await piscina.run({ port: channel.port1 }, { transferList: [channel.port1] });
 })();

--- a/examples/move/index.js
+++ b/examples/move/index.js
@@ -10,6 +10,6 @@ const pool = new Piscina({
   // The task will transfer an ArrayBuffer
   // back to the main thread rather than
   // cloning it.
-  const u8 = await pool.runTask();
+  const u8 = await pool.run();
   console.log(u8.length);
 })();

--- a/examples/multiple-workers/index.js
+++ b/examples/multiple-workers/index.js
@@ -11,7 +11,7 @@ const pool = new Piscina();
 
 (async () => {
   console.log(await Promise.all([
-    pool.runTask({ a: 2, b: 3 }, resolve(__dirname, 'add_worker')),
-    pool.runTask({ a: 2, b: 3 }, resolve(__dirname, 'multiply_worker'))
+    pool.run({ a: 2, b: 3 }, { filename: resolve(__dirname, 'add_worker') }),
+    pool.run({ a: 2, b: 3 }, { filename: resolve(__dirname, 'multiply_worker') })
   ]));
 })();

--- a/examples/n-api/README.md
+++ b/examples/n-api/README.md
@@ -37,11 +37,11 @@ const pool = new Piscina({
 (async () => {
   // Submit 5 concurrent tasks
   console.log(await Promise.all([
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask()
+    pool.run(),
+    pool.run(),
+    pool.run(),
+    pool.run(),
+    pool.run()
   ]));
 })();
 ```

--- a/examples/n-api/index.js
+++ b/examples/n-api/index.js
@@ -7,10 +7,10 @@ const pool = new Piscina({
 
 (async () => {
   console.log(await Promise.all([
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask(),
-    pool.runTask()
+    pool.run(),
+    pool.run(),
+    pool.run(),
+    pool.run(),
+    pool.run()
   ]));
 })();

--- a/examples/named/index.js
+++ b/examples/named/index.js
@@ -10,8 +10,8 @@ const piscina = new Piscina({
 
 (async function () {
   const result = await Promise.all([
-    piscina.runTask(makeTask('add', 4, 6)),
-    piscina.runTask(makeTask('sub', 4, 6))
+    piscina.run(makeTask('add', 4, 6)),
+    piscina.run(makeTask('sub', 4, 6))
   ]);
   console.log(result);
 })();

--- a/examples/progress/index.js
+++ b/examples/progress/index.js
@@ -16,7 +16,7 @@ async function task (a, b) {
   const mc = new MessageChannel();
   mc.port2.onmessage = () => bar.tick();
   mc.port2.unref();
-  return await piscina.runTask({ a, b, port: mc.port1 }, [mc.port1]);
+  return await piscina.run({ a, b, port: mc.port1 }, { transferList: [mc.port1] });
 }
 
 Promise.all([

--- a/examples/resourceLimits/index.js
+++ b/examples/resourceLimits/index.js
@@ -15,7 +15,7 @@ const piscina = new Piscina({
 
 (async function () {
   try {
-    await piscina.runTask();
+    await piscina.run();
   } catch (err) {
     console.log('Worker terminated due to resource limits');
     strictEqual(err.code, 'ERR_WORKER_OUT_OF_MEMORY');

--- a/examples/scrypt/pooled.js
+++ b/examples/scrypt/pooled.js
@@ -42,7 +42,7 @@ async function * generateInput () {
   const keylen = 64;
 
   for await (const input of generateInput()) {
-    await piscina.runTask({ input, keylen });
+    await piscina.run({ input, keylen });
   }
 
   performance.mark('end');

--- a/examples/scrypt/pooled_sync.js
+++ b/examples/scrypt/pooled_sync.js
@@ -41,7 +41,7 @@ async function * generateInput () {
   const keylen = 64;
 
   for await (const input of generateInput()) {
-    await piscina.runTask({ input, keylen });
+    await piscina.run({ input, keylen });
   }
 
   performance.mark('end');

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -8,6 +8,6 @@ const piscina = new Piscina({
 });
 
 (async function () {
-  const result = await piscina.runTask({ a: 4, b: 6 });
+  const result = await piscina.run({ a: 4, b: 6 });
   console.log(result); // Prints 10
 })();

--- a/examples/simple_async/index.js
+++ b/examples/simple_async/index.js
@@ -8,6 +8,6 @@ const piscina = new Piscina({
 });
 
 (async function () {
-  const result = await piscina.runTask({ a: 4, b: 6 });
+  const result = await piscina.run({ a: 4, b: 6 });
   console.log(result); // Prints 10
 })();

--- a/examples/stream-in/index.js
+++ b/examples/stream-in/index.js
@@ -43,7 +43,7 @@ stream
   .on('data', (data) => {
     const line = data.toString('utf8');
     progress.incSubmitted();
-    pool.runTask(line)
+    pool.run(line)
       .then(() => {
         progress.incCompleted();
       })

--- a/examples/stream/index.mjs
+++ b/examples/stream/index.mjs
@@ -9,7 +9,7 @@ const pool = new Piscina({
 
 const { port1, port2 } = new MessageChannel();
 
-pool.runTask(port2, [port2]);
+pool.run(port2, { transferList: [port2] });
 
 const duplex = new MessagePortDuplex(port1);
 pipeline(

--- a/examples/task-queue/index.js
+++ b/examples/task-queue/index.js
@@ -48,13 +48,13 @@ function makeTask (task, priority) {
 (async () => {
   // Submit enough tasks to ensure that at least some are queued
   console.log(await Promise.all([
-    pool.runTask(makeTask({ priority: 1 }, 1)),
-    pool.runTask(makeTask({ priority: 2 }, 2)),
-    pool.runTask(makeTask({ priority: 3 }, 3)),
-    pool.runTask(makeTask({ priority: 4 }, 4)),
-    pool.runTask(makeTask({ priority: 5 }, 5)),
-    pool.runTask(makeTask({ priority: 6 }, 6)),
-    pool.runTask(makeTask({ priority: 7 }, 7)),
-    pool.runTask(makeTask({ priority: 8 }, 8))
+    pool.run(makeTask({ priority: 1 }, 1)),
+    pool.run(makeTask({ priority: 2 }, 2)),
+    pool.run(makeTask({ priority: 3 }, 3)),
+    pool.run(makeTask({ priority: 4 }, 4)),
+    pool.run(makeTask({ priority: 5 }, 5)),
+    pool.run(makeTask({ priority: 6 }, 6)),
+    pool.run(makeTask({ priority: 7 }, 7)),
+    pool.run(makeTask({ priority: 8 }, 8))
   ]));
 })();

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -11,7 +11,7 @@ if (isMainThread) {
 
   (async function () {
     const task : Inputs = { a: 1, b: 2 };
-    console.log(await piscina.runTask(task));
+    console.log(await piscina.run(task));
   })();
 } else {
   module.exports = ({ a, b } : Inputs) : number => {

--- a/examples/worker_options/index.js
+++ b/examples/worker_options/index.js
@@ -12,6 +12,6 @@ const piscina = new Piscina({
 });
 
 (async function () {
-  const result = await piscina.runTask({ a: 4, b: 6 });
+  const result = await piscina.run({ a: 4, b: 6 });
   console.log(result); // Prints 10
 })();

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -28,6 +28,7 @@ test('tasks can be aborted through EventEmitter while running', async ({ equal, 
   const buf = new Int32Array(new SharedArrayBuffer(4));
   const ee = new EventEmitter();
   rejects(pool.runTask(buf, ee), /The task has been aborted/);
+  rejects(pool.run(buf, { signal: ee }), /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
   equal(Atomics.load(buf, 0), 1);
@@ -48,7 +49,8 @@ test('tasks can be aborted through EventEmitter before running', async ({ equal,
   const task1 = pool.runTask(bufs[0]);
   const ee = new EventEmitter();
   rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
-  equal(pool.queueSize, 1);
+  rejects(pool.run(bufs[1], { signal: ee }), /The task has been aborted/);
+  equal(pool.queueSize, 2);
 
   ee.emit('abort');
 

--- a/test/move-test.ts
+++ b/test/move-test.ts
@@ -88,4 +88,20 @@ test('Moving works', async ({ equal, ok }) => {
     equal(ab.byteLength, 0); // It was moved
     ok(types.isAnyArrayBuffer(ret));
   }
+
+  {
+    // Test with empty transferList
+    const ab = new ArrayBuffer(10);
+    const ret = await pool.run(Piscina.move(ab));
+    equal(ab.byteLength, 0); // It was moved
+    ok(types.isAnyArrayBuffer(ret));
+  }
+
+  {
+    // Test with empty transferList
+    const ab = new ArrayBuffer(10);
+    const ret = await pool.run(Piscina.move(ab), { transferList: [] });
+    equal(ab.byteLength, 0); // It was moved
+    ok(types.isAnyArrayBuffer(ret));
+  }
 });

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -14,6 +14,17 @@ test('postTask() can transfer ArrayBuffer instances', async ({ equal }) => {
   equal(ab.byteLength, 0);
 });
 
+test('postTask() can transfer ArrayBuffer instances', async ({ equal }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
+  });
+
+  const ab = new ArrayBuffer(40);
+  await pool.run({ ab }, { transferList: [ab] });
+  equal(pool.completed, 1);
+  equal(ab.byteLength, 0);
+});
+
 test('postTask() cannot clone build-in objects', async ({ rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
@@ -46,6 +57,9 @@ test('postTask() validates transferList', async ({ rejects }) => {
 
   rejects(pool.runTask('0', 42 as any),
     /transferList argument must be an Array/);
+
+  rejects(pool.run('0', { transferList: 42 as any }),
+    /transferList argument must be an Array/);
 });
 
 test('postTask() validates filename', async ({ rejects }) => {
@@ -55,6 +69,9 @@ test('postTask() validates filename', async ({ rejects }) => {
 
   rejects(pool.runTask('0', [], 42 as any),
     /filename argument must be a string/);
+
+  rejects(pool.run('0', { filename: 42 as any }),
+    /filename argument must be a string/);
 });
 
 test('postTask() validates abortSignal', async ({ rejects }) => {
@@ -63,7 +80,10 @@ test('postTask() validates abortSignal', async ({ rejects }) => {
   });
 
   rejects(pool.runTask('0', [], undefined, 42 as any),
-    /abortSignal argument must be an object/);
+    /signal argument must be an object/);
+
+  rejects(pool.run('0', { signal: 42 as any }),
+    /signal argument must be an object/);
 });
 
 test('Piscina emits drain', async ({ ok }) => {
@@ -93,4 +113,12 @@ test('Piscina can use async loaded esm workers', {}, async ({ equal }) => {
     filename: resolve(__dirname, 'fixtures/esm-async.mjs')
   });
   equal(await pool.runTask('1'), 1);
+});
+
+test('Piscina.run options is correct type', async ({ rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  rejects(pool.run(42, 1 as any), /options must be an object/);
 });

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -77,7 +77,7 @@ test('filename can be null when initially provided', async ({ equal }) => {
 test('filename must be provided while posting', async ({ rejects }) => {
   const worker = new Piscina();
   rejects(worker.runTask('doesn’t matter'),
-    /filename must be provided to runTask\(\) or in options object/);
+    /filename must be provided to run\(\) or in options object/);
 });
 
 test('passing env to workers works', async ({ same }) => {
@@ -165,4 +165,12 @@ test('duration and utilization calculations work', async ({ equal, ok }) => {
 
   // Duration must be non-zero.
   ok(worker.duration > 0);
+});
+
+test('run works also', async () => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  await worker.run(42);
 });


### PR DESCRIPTION
The `runTask()` method uses positioned arguments for various
inputs, making the signature and the argument validation
fairly complicated. This makes it more difficult to add new
options later.

This commit introduces a new `run()` function that accepts an
options object instead, e.g.

```js
piscina.run({ a: 1 }, { filename: '...', signal: ... });
```

This will be more scalable in the long run if new options need
to be added.

This marks the `runTask()` variant as deprecated.