### PR TITLE
Support multiple worker functions per file

### DIFF
--- a/examples/move/index.js
+++ b/examples/move/index.js
@@ -10,6 +10,6 @@ const pool = new Piscina({
   // The task will transfer an ArrayBuffer
   // back to the main thread rather than
   // cloning it.
-  const u8 = await pool.run();
+  const u8 = await pool.run(Piscina.move(new Uint8Array(2)));
   console.log(u8.length);
 })();

--- a/examples/multiple-workers-one-file/index.js
+++ b/examples/multiple-workers-one-file/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Piscina = require('../..');
+const { resolve } = require('path');
+
+// It is possible for a single Piscina pool to run multiple
+// workers at the same time. To do so, pass the worker filename
+// to runTask rather than to the Piscina constructor.
+
+const pool = new Piscina({ filename: resolve(__dirname, 'worker.js') });
+
+(async () => {
+  console.log(await Promise.all([
+    pool.run({ a: 2, b: 3 }, { name: 'add' }),
+    pool.run({ a: 2, b: 3 }, { name: 'multiply' })
+  ]));
+})();

--- a/examples/multiple-workers-one-file/index.mjs
+++ b/examples/multiple-workers-one-file/index.mjs
@@ -1,0 +1,10 @@
+import { Piscina } from 'piscina';
+
+const pool = new Piscina({
+  filename: new URL('./worker.mjs', import.meta.url).href
+});
+
+console.log(await Promise.all([
+  pool.run({ a: 2, b: 3 }, { name: 'add' }),
+  pool.run({ a: 2, b: 3 }, { name: 'multiply' })
+]));

--- a/examples/multiple-workers-one-file/worker.js
+++ b/examples/multiple-workers-one-file/worker.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function add ({ a, b }) { return a + b; }
+function multiply ({ a, b }) { return a * b; };
+
+add.add = add;
+add.multiply = multiply;
+
+// The add function is the default handler, but
+// additional named handlers are exported.
+module.exports = add;

--- a/examples/multiple-workers-one-file/worker.mjs
+++ b/examples/multiple-workers-one-file/worker.mjs
@@ -1,0 +1,4 @@
+export function add ({ a, b }) { return a + b; }
+export function multiply ({ a, b }) { return a * b; };
+
+export default add;

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,6 +2,7 @@ import type { MessagePort } from 'worker_threads';
 
 export interface StartupMessage {
   filename : string | null;
+  name : string;
   port : MessagePort;
   sharedBuffer : Int32Array;
   useAtomics : boolean;
@@ -12,6 +13,7 @@ export interface RequestMessage {
   taskId : number;
   task : any;
   filename: string;
+  name : string;
 }
 
 export interface ReadyMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -34,8 +34,8 @@ function getImportESM () {
 
 // Look up the handler function that we call when a task is posted.
 // This is either going to be "the" export from a file, or the default export.
-async function getHandler (filename : string) : Promise<Function | null> {
-  let handler = handlerCache.get(filename);
+async function getHandler (filename : string, name : string) : Promise<Function | null> {
+  let handler = handlerCache.get(`${filename}/${name}`);
   if (handler !== undefined) {
     return handler;
   }
@@ -45,13 +45,13 @@ async function getHandler (filename : string) : Promise<Function | null> {
     // `require(filename)`.
     handler = await import(filename);
     if (typeof handler !== 'function') {
-      handler = await (handler as any).default;
+      handler = await ((handler as any)[name]);
     }
   } catch {}
   if (typeof handler !== 'function') {
     handler = await getImportESM()(pathToFileURL(filename).href);
     if (typeof handler !== 'function') {
-      handler = await (handler as any).default;
+      handler = await ((handler as any)[name]);
     }
   }
   if (typeof handler !== 'function') {
@@ -65,7 +65,7 @@ async function getHandler (filename : string) : Promise<Function | null> {
     handlerCache.delete(key);
   }
 
-  handlerCache.set(filename, handler);
+  handlerCache.set(`${filename}/${name}`, handler);
   return handler;
 }
 
@@ -75,7 +75,7 @@ async function getHandler (filename : string) : Promise<Function | null> {
 // (so we can pre-load and cache the handler).
 parentPort!.on('message', (message : StartupMessage) => {
   useAtomics = message.useAtomics;
-  const { port, sharedBuffer, filename, niceIncrement } = message;
+  const { port, sharedBuffer, filename, name, niceIncrement } = message;
   (async function () {
     try {
       if (niceIncrement !== 0 && process.platform === 'linux') {
@@ -86,7 +86,7 @@ parentPort!.on('message', (message : StartupMessage) => {
     } catch {}
 
     if (filename !== null) {
-      await getHandler(filename);
+      await getHandler(filename, name);
     }
 
     const readyMessage : ReadyMessage = { ready: true };
@@ -134,13 +134,13 @@ function onMessage (
   sharedBuffer : Int32Array,
   message : RequestMessage) {
   currentTasks++;
-  const { taskId, task, filename } = message;
+  const { taskId, task, filename, name } = message;
 
   (async function () {
     let response : ResponseMessage;
     const transferList : any[] = [];
     try {
-      const handler = await getHandler(filename);
+      const handler = await getHandler(filename, name);
       if (handler === null) {
         throw new Error(`No handler function exported from ${filename}`);
       }

--- a/test/fixtures/multiple.js
+++ b/test/fixtures/multiple.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function a () { return 'a'; }
+
+function b () { return 'b'; }
+
+a.a = a;
+a.b = b;
+
+module.exports = a;

--- a/test/option-validation.ts
+++ b/test/option-validation.ts
@@ -7,6 +7,12 @@ test('filename cannot be non-null/non-string', async ({ throws }) => {
   }) as any), /options.filename must be a string or null/);
 });
 
+test('name cannot be non-null/non-string', async ({ throws }) => {
+  throws(() => new Piscina(({
+    name: 12
+  }) as any), /options.name must be a string or null/);
+});
+
 test('minThreads must be non-negative integer', async ({ throws }) => {
   throws(() => new Piscina(({
     minThreads: -1

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -74,6 +74,15 @@ test('postTask() validates filename', async ({ rejects }) => {
     /filename argument must be a string/);
 });
 
+test('postTask() validates name', async ({ rejects }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  rejects(pool.run('0', { name: 42 as any }),
+    /name argument must be a string/);
+});
+
 test('postTask() validates abortSignal', async ({ rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -174,3 +174,24 @@ test('run works also', async () => {
 
   await worker.run(42);
 });
+
+test('named tasks work', async ({ equal }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/multiple.js')
+  });
+
+  equal(await worker.run({}, { name: 'a' }), 'a');
+  equal(await worker.run({}, { name: 'b' }), 'b');
+  equal(await worker.run({}), 'a');
+});
+
+test('named tasks work', async ({ equal }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/multiple.js'),
+    name: 'b'
+  });
+
+  equal(await worker.run({}, { name: 'a' }), 'a');
+  equal(await worker.run({}, { name: 'b' }), 'b');
+  equal(await worker.run({}), 'b');
+});


### PR DESCRIPTION
Implements support for exporting multiple worker functions per worker.

worker.js:
```js
function add({ a, b }) { return a + b; }

function multiply({ a, b }) { return a * b; }

add.add = add;
add.multiply = multiply;

module.exports = add;
```

Then when running a task:

```js
piscina.run({ a: 2, b: 5 }, { name: 'add' });
piscina.run({ a: 2, b: 5 }, { name: 'multiply' });
```

