### PR TITLE
fix: transferrable not being transferred

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -146,7 +146,7 @@ function onMessage (
       }
       let result = await handler(task);
       if (isMovable(result)) {
-        transferList = result[kTransferable];
+        transferList = transferList.concat(result[kTransferable]);
         result = result[kValue];
       }
       response = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -138,7 +138,7 @@ function onMessage (
 
   (async function () {
     let response : ResponseMessage;
-    const transferList : any[] = [];
+    let transferList : any[] = [];
     try {
       const handler = await getHandler(filename, name);
       if (handler === null) {
@@ -146,7 +146,7 @@ function onMessage (
       }
       let result = await handler(task);
       if (isMovable(result)) {
-        transferList.concat(result[kTransferable]);
+        transferList = result[kTransferable];
         result = result[kValue];
       }
       response = {

--- a/test/fixtures/send-buffer-then-get-length.js
+++ b/test/fixtures/send-buffer-then-get-length.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Piscina = require('../../dist/src');
+
+const response = {};
+module.exports = {
+  send: async () => {
+    const data = Buffer.from('this is a test').buffer;
+    try {
+      return Piscina.move(data)
+    } finally {
+      response.initial = data.byteLength;
+      setTimeout(() => { response.after = data.byteLength; }, 1000);
+    }
+  },
+  get: () => {
+    return response;
+  }
+}

--- a/test/fixtures/send-buffer-then-get-length.js
+++ b/test/fixtures/send-buffer-then-get-length.js
@@ -2,18 +2,17 @@
 
 const Piscina = require('../../dist/src');
 
-const response = {};
+let time;
 module.exports = {
   send: async () => {
-    const data = Buffer.from('this is a test').buffer;
+    const data = new ArrayBuffer(128);
     try {
-      return Piscina.move(data)
+      return Piscina.move(data);
     } finally {
-      response.initial = data.byteLength;
-      setTimeout(() => { response.after = data.byteLength; }, 1000);
+      setTimeout(() => { time = data.byteLength; }, 1000);
     }
   },
   get: () => {
-    return response;
+    return time;
   }
-}
+};

--- a/test/fixtures/send-transferrable-then-get-length.js
+++ b/test/fixtures/send-transferrable-then-get-length.js
@@ -21,19 +21,18 @@ class Shared {
   }
 }
 
-const response = {};
+let time;
 module.exports = {
   send: async () => {
-    const data = Buffer.from('this is a test').buffer;
+    const data = new ArrayBuffer(128);
     const shared = new Shared(data);
     try {
       return shared.make();
     } finally {
-      response.initial = data.byteLength;
-      setTimeout(() => { response.after = data.byteLength; }, 1000);
+      setTimeout(() => { time = data.byteLength; }, 1000);
     }
   },
   get: () => {
-    return response;
+    return time;
   }
-}
+};

--- a/test/fixtures/send-transferrable-then-get-length.js
+++ b/test/fixtures/send-transferrable-then-get-length.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const Piscina = require('../../dist/src');
+
+class Shared {
+  constructor (data) {
+    this.name = 'shared';
+    this.data = data;
+  }
+
+  get [Piscina.transferableSymbol] () {
+    return [this.data];
+  }
+
+  get [Piscina.valueSymbol] () {
+    return { name: this.name, data: this.data };
+  }
+
+  make () {
+    return Piscina.move(this);
+  }
+}
+
+const response = {};
+module.exports = {
+  send: async () => {
+    const data = Buffer.from('this is a test').buffer;
+    const shared = new Shared(data);
+    try {
+      return shared.make();
+    } finally {
+      response.initial = data.byteLength;
+      setTimeout(() => { response.after = data.byteLength; }, 1000);
+    }
+  },
+  get: () => {
+    return response;
+  }
+}

--- a/test/test-is-buffer-transferred.ts
+++ b/test/test-is-buffer-transferred.ts
@@ -1,0 +1,29 @@
+import Piscina from '../dist/src';
+import { test } from 'tap';
+import { resolve } from 'path';
+
+function wait() {
+  return new Promise(res => setTimeout(res, 1250));
+}
+
+test('transferable objects must be transferred', async ({ not }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/send-buffer-then-get-length.js'),
+    useAtomics: false
+  });
+  await pool.run({}, { name: 'send' });
+  await wait();
+  const { initial, after } = await pool.run({}, { name: 'get' });
+  not(initial, after);
+});
+
+test('objects that implement transferable must be transferred', async ({ not }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/send-transferrable-then-get-length.js'),
+    useAtomics: false
+  });
+  await pool.run({}, { name: 'send' });
+  await wait();
+  const { initial, after } = await pool.run({}, { name: 'get' });
+  not(initial, after);
+});

--- a/test/test-is-buffer-transferred.ts
+++ b/test/test-is-buffer-transferred.ts
@@ -2,28 +2,28 @@ import Piscina from '../dist/src';
 import { test } from 'tap';
 import { resolve } from 'path';
 
-function wait() {
-  return new Promise(res => setTimeout(res, 1250));
+function wait () {
+  return new Promise((resolve) => setTimeout(resolve, 1500));
 }
 
-test('transferable objects must be transferred', async ({ not }) => {
+test('transferable objects must be transferred', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/send-buffer-then-get-length.js'),
     useAtomics: false
   });
   await pool.run({}, { name: 'send' });
   await wait();
-  const { initial, after } = await pool.run({}, { name: 'get' });
-  not(initial, after);
+  const after = await pool.run({}, { name: 'get' });
+  equal(after, 0);
 });
 
-test('objects that implement transferable must be transferred', async ({ not }) => {
+test('objects that implement transferable must be transferred', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/send-transferrable-then-get-length.js'),
     useAtomics: false
   });
   await pool.run({}, { name: 'send' });
   await wait();
-  const { initial, after } = await pool.run({}, { name: 'get' });
-  not(initial, after);
+  const after = await pool.run({}, { name: 'get' });
+  equal(after, 0);
 });


### PR DESCRIPTION
I noticed that returning a `Transferable objects` from a worker doesn't get the object transferred, instead it's being cloned.

To verify this, I created my own Implementation of Transferrable
```js
class Shared {
    constructor({ ok, time, data } = {}) {
        this.ok = ok;
        this.time = time;
        this.data = data;
    }

    get [Piscina.transferableSymbol]() {
        return [this.data];
    }

    get [Piscina.valueSymbol]() {
        return { ok: this.ok, time: this.time, data: this.data };
    }

    make() {
        return Piscina.move(this);
    }
}

module.exports = Shared;
```
Then logged my buffer's byteLength intially, then after 1 second.

Without this fix, the byteLength didn't change, which signifies the buffer was not transferred
![image](https://user-images.githubusercontent.com/36309350/137945957-72039a01-bf42-45e6-9c44-3d51c4eb55fd.png)
With the fix, the byteLength did change, which signifies the buffer was transferred
![image](https://user-images.githubusercontent.com/36309350/137946043-6816543b-9a73-42e7-8559-9b6964fa8ca3.png)
