### PR TITLE
feat(atomics): add environment variable to disable atomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,8 @@ This class extends [`EventEmitter`][] from Node.js.
     to the task. Keep in mind that Worker threads are generally not built for
     handling I/O in parallel.
   * `useAtomics`: (`boolean`) Use the [`Atomics`][] API for faster communication
-    between threads. This is on by default.
+    between threads. This is on by default. You can disable `Atomics` globally by
+    setting the environment variable `PISCINA_DISABLE_ATOMICS` to `1`.
   * `resourceLimits`: (`object`) See [Node.js new Worker options][]
     * `maxOldGenerationSizeMb`: (`number`) The maximum size of each worker threads
       main heap in MB.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -17,7 +17,7 @@ commonState.isWorkerThread = true;
 commonState.workerData = workerData;
 
 const handlerCache : Map<string, Function> = new Map();
-let useAtomics : boolean = true;
+let useAtomics : boolean = process.env.PISCINA_DISABLE_ATOMICS !== '1';
 
 // Get `import(x)` as a function that isn't transpiled to `require(x)` by
 // TypeScript for dual ESM/CJS support.
@@ -74,7 +74,7 @@ async function getHandler (filename : string, name : string) : Promise<Function 
 // communication using Atomics, and the name of the default filename for tasks
 // (so we can pre-load and cache the handler).
 parentPort!.on('message', (message : StartupMessage) => {
-  useAtomics = message.useAtomics;
+  useAtomics = process.env.PISCINA_DISABLE_ATOMICS === '1' ? false : message.useAtomics;
   const { port, sharedBuffer, filename, name, niceIncrement } = message;
   (async function () {
     try {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,6 +26,7 @@ let useAtomics : boolean = process.env.PISCINA_DISABLE_ATOMICS !== '1';
 let importESMCached : (specifier : string) => Promise<any> | undefined;
 function getImportESM () {
   if (importESMCached === undefined) {
+    // eslint-disable-next-line no-new-func
     importESMCached = new Function('specifier', 'return import(specifier)') as typeof importESMCached;
   }
   return importESMCached;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,8 +26,7 @@ let useAtomics : boolean = process.env.PISCINA_DISABLE_ATOMICS !== '1';
 let importESMCached : (specifier : string) => Promise<any> | undefined;
 function getImportESM () {
   if (importESMCached === undefined) {
-    // eslint-disable-next-line no-eval
-    importESMCached = eval('(specifier) => import(specifier)');
+    importESMCached = new Function('specifier', 'return import(specifier)') as typeof importESMCached;
   }
   return importESMCached;
 }


### PR DESCRIPTION
Hi 👋 !

As discussed privately, it would be nice for runtimes to disable the use of `Atomics` globally as it does not change the outcome at all. A runtime like WebContainer runs in the browser and is currently not capable of implementing `receiveMessageOnPort` as the browser does not have such implementation.

By adding this environment variable, we are capable of turning it off in general and make piscina work out-of-the-box in StackBlitz WebContainers.

Feel free to suggest different wording for the readme.

Sam