### PR TITLE
fix: Fix types for TypeScript 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A fast, efficient Node.js Worker Thread Pool implementation",
   "main": "./dist/src/index.js",
   "exports": {
+    "types": "./dist/src/index.d.ts",
     "import": "./dist/esm-wrapper.mjs",
     "require": "./dist/src/index.js"
   },


### PR DESCRIPTION
The module's type definition file could not be found in some cases of TypeScript 4.7, this PR resolves the issue.

Reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing