### PR TITLE
Option to create `WORKER_ID` env var in threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ This class extends [`EventEmitter`][] from Node.js.
     `fs.close()`, and will close them automatically when the Worker exits.
     Defaults to `true`. (This option is only supported on Node.js 12.19+ and
     all Node.js versions higher than 14.6.0).
+  * `workerIdEnv`: (`boolean|string`) If `true`, sets an environment variable in
+    worker threads `WORKER_ID` with the ID of each thread (`process.env.WORKER_ID`).
+    If a string, that name is used instead of `WORKER_ID`.
 
 Use caution when setting resource limits. Setting limits that are too low may
 result in the `Piscina` worker threads being unusable.

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,6 +2,8 @@ import type { MessagePort } from 'worker_threads';
 
 export const READY = '_WORKER_READY';
 
+export const DEFAULT_WORKER_ID_ENV = 'WORKER_ID';
+
 export interface StartupMessage {
   filename : string | null;
   name : string;

--- a/test/worker-id.ts
+++ b/test/worker-id.ts
@@ -1,0 +1,86 @@
+import Piscina from '..';
+import { test } from 'tap';
+import { resolve } from 'path';
+
+test('workerIdEnv: undefined creates no env var', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  const isUndefined = await pool.runTask('process.env.WORKER_ID === undefined');
+  same(isUndefined, true);
+});
+
+test('workerIdEnv: false creates no env var', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    workerIdEnv: false
+  });
+
+  const isUndefined = await pool.runTask('process.env.WORKER_ID === undefined');
+  same(isUndefined, true);
+});
+
+test('workerIdEnv: true creates env var with name WORKER_ID', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    workerIdEnv: true,
+    minThreads: 1
+  });
+
+  const id = await pool.runTask('process.env.WORKER_ID');
+  same(id, '1');
+});
+
+test('workerIdEnv: FOO_ID creates env var with name FOO_ID', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    workerIdEnv: 'FOO_ID',
+    minThreads: 1
+  });
+
+  const id = await pool.runTask('process.env.FOO_ID');
+  same(id, '1');
+});
+
+test('Same WORKER_ID for tasks run on same thread', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    workerIdEnv: true,
+    minThreads: 1,
+    maxThreads: 1
+  });
+
+  for (let i = 0; i < 4; i++) {
+    const { id, isNew, pastId } = await pool.runTask(`const id = process.env.WORKER_ID; ({
+      id: process.env.WORKER_ID,
+      isNew: !globalThis.__id__,
+      pastId: globalThis.__id__ || (globalThis.__id__ = id)
+    })`);
+    same(id, 1);
+    same(isNew, i === 0);
+    same(pastId, id);
+  }
+});
+
+test('Same WORKER_ID for tasks run on same thread', async ({ same }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    workerIdEnv: true,
+    minThreads: 2,
+    maxThreads: 2
+  });
+
+  const ids = new Set();
+  await Promise.all([0, 1, 2, 3, 4, 5, 6, 7].map(async (i) => {
+    const { id, isNew, pastId } = await pool.runTask(`const id = process.env.WORKER_ID; ({
+      id: process.env.WORKER_ID,
+      isNew: !globalThis.__id__,
+      pastId: globalThis.__id__ || (globalThis.__id__ = id)
+    })`);
+    ids.add(id);
+    same(id, pastId);
+    same(isNew, i < 2);
+  }));
+  same([...ids].sort(), [1, 2]);
+});


### PR DESCRIPTION
This PR adds an option `workerIdEnv` which results in each thread having an environment variable set with the ID of the thread. NB The thread, not the task.

* `workerIdEnv: true` sets a var `process.env.WORKER_ID`
* `workerIdEnv: 'FOO_ID'` sets a var `process.env.FOO_ID`
* Default behavior is to do nothing (no breaking change)

Use case: Debugging running different tasks across threads. If one task is poisoning the thread environment somehow and causing failures later in unrelated tasks run in the same thread, it's helpful to understand what is running in which thread.

I've run into exactly this problem while using [jest-light-runner](https://www.npmjs.com/package/jest-light-runner) which runs each test file in a Piscina pool. One test was passing, but it left `global` in a bad state which caused failures in other unrelated test files, purely by the accident that they ran on same thread. Figuring out the source of the fault was difficult without being able to narrow down which other test files ran on the same thread as the failing test.

Two queries about the content of this PR:

1. I'm not a TypeScripter and had difficulty with the type checker on one line. Perhaps someone can advise how to get around this? https://github.com/overlookmotel/piscina/blob/worker-ids/src/index.ts#L586-L591
2. Query: If `options.env === undefined`, this currently copies the main thread's `process.env` before adding `WORKER_ID`. Inheriting parent's env is the default behavior with worker threads, right?