### PR TITLE
test: fix issue at new Node versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -123,8 +123,10 @@ test('passing valid workerData works', async ({ equal }) => {
 test('passing invalid workerData does not work', async ({ throws }) => {
   throws(() => new Piscina(({
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
-    workerData: process.env
-  }) as any), /Cannot transfer object of unsupported type./);
+    workerData: {
+      hello () {}
+    }
+  }) as any), /could not be cloned./);
 });
 
 test('filename can be a file:// URL', async ({ equal }) => {


### PR DESCRIPTION
The PR adjusts some tests that was leading to failures at most recent Node.js versions (i.e. `20` and `18`)