### PR TITLE
refactor!: drop runTask method

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,33 +389,6 @@ an error, the returned `Promise` will be rejected with that error.
 If the task is aborted, the returned `Promise` is rejected with an error
 as well.
 
-### Method: `runTask(task[, transferList][, filename][, abortSignal])`
-
-**Deprecated** -- Use `run(task, options)` instead.
-
-Schedules a task to be run on a Worker thread.
-
-* `task`: Any value. This will be passed to the function that is exported from
-  `filename`.
-* `transferList`: An optional lists of objects that is passed to
-  [`postMessage()`] when posting `task` to the Worker, which are transferred
-  rather than cloned.
-* `filename`: Optionally overrides the `filename` option passed to the
-  constructor for this task. If no `filename` was specified to the constructor,
-  this is mandatory.
-* `abortSignal`: An [`AbortSignal`][] instance. If passed, this can be used to
-  cancel a task. If the task is already running, the corresponding `Worker`
-  thread will be stopped.
-  (More generally, any `EventEmitter` or `EventTarget` that emits `'abort'`
-  events can be passed here.) Abortable tasks cannot share threads regardless
-  of the `concurrentTasksPerWorker` options.
-
-This returns a `Promise` for the return value of the (async) function call
-made to the function exported from `filename`. If the (async) function throws
-an error, the returned `Promise` will be rejected with that error.
-If the task is aborted, the returned `Promise` is rejected with an error
-as well.
-
 ### Method: `destroy()`
 
 Stops all Workers and rejects all `Promise`s for pending tasks.
@@ -708,7 +681,7 @@ An example of a custom task queue that uses a shuffled priority queue
 is available in [`examples/task-queue`](./examples/task-queue/index.js);
 
 The special symbol `Piscina.queueOptionsSymbol` may be set as a property
-on tasks submitted to `run()` or `runTask()` as a way of passing additional
+on tasks submitted to `run()` as a way of passing additional
 options on to the custom `TaskQueue` implementation. (Note that because the
 queue options are set as a property on the task, tasks with queue
 options cannot be submitted as JavaScript primitives).

--- a/benchmark/simple-benchmark.js
+++ b/benchmark/simple-benchmark.js
@@ -14,7 +14,7 @@ async function simpleBenchmark ({ duration = 10000 } = {}) {
 
   async function scheduleTasks () {
     while ((process.hrtime.bigint() - start) / 1_000_000n < duration) {
-      await pool.runTask({ a: 4, b: 6 });
+      await pool.run({ a: 4, b: 6 });
       done++;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1092,54 +1092,6 @@ class Piscina extends EventEmitterAsyncResource {
     this.#pool = new ThreadPool(this, options);
   }
 
-  /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : TransferList, filename? : string, abortSignal? : AbortSignalAny) : Promise<any>;
-
-  /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : TransferList, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
-
-  /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : string, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
-
-  /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : AbortSignalAny, filename? : undefined, abortSignal? : undefined) : Promise<any>;
-
-  /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : any, filename? : any, signal? : any) {
-    // If transferList is a string or AbortSignal, shift it.
-    if ((typeof transferList === 'object' && !Array.isArray(transferList)) ||
-        typeof transferList === 'string') {
-      signal = filename as (AbortSignalAny | undefined);
-      filename = transferList;
-      transferList = undefined;
-    }
-    // If filename is an AbortSignal, shift it.
-    if (typeof filename === 'object' && !Array.isArray(filename)) {
-      signal = filename;
-      filename = undefined;
-    }
-
-    if (transferList !== undefined && !Array.isArray(transferList)) {
-      return Promise.reject(
-        new TypeError('transferList argument must be an Array'));
-    }
-    if (filename !== undefined && typeof filename !== 'string') {
-      return Promise.reject(
-        new TypeError('filename argument must be a string'));
-    }
-    if (signal !== undefined && typeof signal !== 'object') {
-      return Promise.reject(
-        new TypeError('signal argument must be an object'));
-    }
-    return this.#pool.runTask(
-      task, {
-        transferList,
-        filename: filename || null,
-        name: 'default',
-        signal: signal || null
-      });
-  }
-
   run (task : any, options : RunOptions = kDefaultRunOptions) {
     if (options === null || typeof options !== 'object') {
       return Promise.reject(

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,20 +42,6 @@ const cpuCount : number = (() => {
   }
 })();
 
-// interface AbortSignalEventTargetAddOptions {
-//   once : boolean;
-// };
-
-// interface AbortSignalEventTarget {
-//   addEventListener : (
-//     name : 'abort',
-//     listener : () => void,
-//     options? : AbortSignalEventTargetAddOptions) => void;
-//   removeEventListener : (
-//     name : 'abort',
-//     listener : () => void) => void;
-//   aborted? : boolean;
-// }
 interface AbortSignalEventEmitter {
   off : (name : 'abort', listener : () => void) => void;
   once : (name : 'abort', listener : () => void) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,25 +42,27 @@ const cpuCount : number = (() => {
   }
 })();
 
-interface AbortSignalEventTargetAddOptions {
-  once : boolean;
-};
+// interface AbortSignalEventTargetAddOptions {
+//   once : boolean;
+// };
 
-interface AbortSignalEventTarget {
-  addEventListener : (
-    name : 'abort',
-    listener : () => void,
-    options? : AbortSignalEventTargetAddOptions) => void;
-  removeEventListener : (
-    name : 'abort',
-    listener : () => void) => void;
-  aborted? : boolean;
-}
+// interface AbortSignalEventTarget {
+//   addEventListener : (
+//     name : 'abort',
+//     listener : () => void,
+//     options? : AbortSignalEventTargetAddOptions) => void;
+//   removeEventListener : (
+//     name : 'abort',
+//     listener : () => void) => void;
+//   aborted? : boolean;
+// }
 interface AbortSignalEventEmitter {
   off : (name : 'abort', listener : () => void) => void;
   once : (name : 'abort', listener : () => void) => void;
 }
-type AbortSignalAny = AbortSignalEventTarget | AbortSignalEventEmitter;
+
+// eslint-disable-next-line
+type AbortSignalAny = AbortSignal | AbortSignalEventEmitter;
 function onabort (abortSignal : AbortSignalAny, listener : () => void) {
   if ('addEventListener' in abortSignal) {
     abortSignal.addEventListener('abort', listener, { once: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,7 @@ interface AbortSignalEventEmitter {
   once : (name : 'abort', listener : () => void) => void;
 }
 
-// eslint-disable-next-line
-type AbortSignalAny = AbortSignal | AbortSignalEventEmitter;
+type AbortSignalAny = globalThis.AbortSignal | AbortSignalEventEmitter;
 function onabort (abortSignal : AbortSignalAny, listener : () => void) {
   if ('addEventListener' in abortSignal) {
     abortSignal.addEventListener('abort', listener, { once: true });
@@ -821,7 +820,7 @@ class ThreadPool {
     if (signal !== null) {
       // If the AbortSignal has an aborted property and it's truthy,
       // reject immediately.
-      if ((signal as AbortSignalEventTarget).aborted) {
+      if ((<globalThis.AbortSignal>signal).aborted) {
         return Promise.reject(new AbortError());
       }
       taskInfo.abortListener = () => {

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -1,4 +1,3 @@
-import { AbortController } from 'abort-controller';
 import { EventEmitter } from 'events';
 import Piscina from '..';
 import { test } from 'tap';
@@ -11,7 +10,7 @@ test('tasks can be aborted through AbortController while running', async ({ equa
 
   const buf = new Int32Array(new SharedArrayBuffer(4));
   const abortController = new AbortController();
-  rejects(pool.runTask(buf, abortController.signal),
+  rejects(pool.run(buf, { signal: abortController.signal }),
     /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
@@ -27,7 +26,6 @@ test('tasks can be aborted through EventEmitter while running', async ({ equal, 
 
   const buf = new Int32Array(new SharedArrayBuffer(4));
   const ee = new EventEmitter();
-  rejects(pool.runTask(buf, ee), /The task has been aborted/);
   rejects(pool.run(buf, { signal: ee }), /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
@@ -46,11 +44,10 @@ test('tasks can be aborted through EventEmitter before running', async ({ equal,
     new Int32Array(new SharedArrayBuffer(4)),
     new Int32Array(new SharedArrayBuffer(4))
   ];
-  const task1 = pool.runTask(bufs[0]);
   const ee = new EventEmitter();
-  rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
+  const task1 = pool.run(bufs[0]);
   rejects(pool.run(bufs[1], { signal: ee }), /The task has been aborted/);
-  equal(pool.queueSize, 2);
+  equal(pool.queueSize, 1);
 
   ee.emit('abort');
 
@@ -71,9 +68,9 @@ test('abortable tasks will not share workers (abortable posted second)', async (
     new Int32Array(new SharedArrayBuffer(4)),
     new Int32Array(new SharedArrayBuffer(4))
   ];
-  const task1 = pool.runTask(bufs[0]);
+  const task1 = pool.run(bufs[0]);
   const ee = new EventEmitter();
-  rejects(pool.runTask(bufs[1], ee), /The task has been aborted/);
+  rejects(pool.run(bufs[1], { signal: ee }), /The task has been aborted/);
   equal(pool.queueSize, 1);
 
   ee.emit('abort');
@@ -92,8 +89,8 @@ test('abortable tasks will not share workers (abortable posted first)', async ({
   });
 
   const ee = new EventEmitter();
-  rejects(pool.runTask('while(true);', ee), /The task has been aborted/);
-  const task2 = pool.runTask('42');
+  rejects(pool.run('while(true);', { signal: ee }), /The task has been aborted/);
+  const task2 = pool.run('42');
   equal(pool.queueSize, 1);
 
   ee.emit('abort');
@@ -116,9 +113,9 @@ test('abortable tasks will not share workers (on worker available)', async ({ eq
   // until after Task 2 completes because it is abortable.
 
   const ret = await Promise.all([
-    pool.runTask({ time: 100, a: 1 }),
-    pool.runTask({ time: 300, a: 2 }),
-    pool.runTask({ time: 100, a: 3 }, new EventEmitter())
+    pool.run({ time: 100, a: 1 }),
+    pool.run({ time: 300, a: 2 }),
+    pool.run({ time: 100, a: 3 }, { signal: new EventEmitter() })
   ]);
 
   equal(ret[0], 0);
@@ -139,12 +136,12 @@ test('abortable tasks will not share workers (destroy workers)', async ({ reject
   // when Task 1 completes, but should not be selected
   // until after Task 2 completes because it is abortable.
 
-  pool.runTask({ time: 100, a: 1 }).then(() => {
+  pool.run({ time: 100, a: 1 }).then(() => {
     pool.destroy();
   });
 
-  rejects(pool.runTask({ time: 300, a: 2 }), /Terminating worker thread/);
-  rejects(pool.runTask({ time: 100, a: 3 }, new EventEmitter()),
+  rejects(pool.run({ time: 300, a: 2 }), /Terminating worker thread/);
+  rejects(pool.run({ time: 100, a: 3 }, { signal: new EventEmitter() }),
     /Terminating worker thread/);
 });
 
@@ -160,7 +157,7 @@ test('aborted AbortSignal rejects task immediately', async ({ rejects, equal }) 
 
   // The data won't be moved because the task will abort immediately.
   const data = new Uint8Array(new SharedArrayBuffer(4));
-  rejects(pool.runTask(data, [data.buffer], controller.signal),
+  rejects(pool.run(data, { signal: controller.signal, transferList: [data.buffer] }),
     /The task has been aborted/);
 
   equal(data.length, 4);
@@ -182,5 +179,5 @@ test('task with AbortSignal cleans up properly', async ({ equal }) => {
 
   const controller = new AbortController();
 
-  await pool.runTask('1+1', controller.signal);
+  await pool.run('1+1', { signal: controller.signal });
 });

--- a/test/abort-task.ts
+++ b/test/abort-task.ts
@@ -170,7 +170,7 @@ test('task with AbortSignal cleans up properly', async ({ equal }) => {
 
   const ee = new EventEmitter();
 
-  await pool.runTask('1+1', ee);
+  await pool.run('1+1', { signal: ee });
 
   const { getEventListeners } = EventEmitter as any;
   if (typeof getEventListeners === 'function') {

--- a/test/async-context.ts
+++ b/test/async-context.ts
@@ -33,7 +33,7 @@ test('postTask() calls the correct async hooks', async ({ equal }) => {
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  await pool.runTask('42');
+  await pool.run('42');
 
   hook.disable();
   equal(initCalls, 1);

--- a/test/atomics-optimization.ts
+++ b/test/atomics-optimization.ts
@@ -16,7 +16,7 @@ test('coverage test for Atomics optimization', async ({ equal }) => {
   // Post 4 tasks, and wait for all of them to be ready.
   const i32array = new Int32Array(new SharedArrayBuffer(4));
   for (let index = 0; index < 4; index++) {
-    tasks.push(pool.runTask({ i32array, index }));
+    tasks.push(pool.run({ i32array, index }));
   }
 
   // Wait for 2 tasks to enter 'wait' state.
@@ -74,7 +74,7 @@ test('avoids unbounded recursion', async () => {
 
   const tasks = [];
   for (let i = 1; i <= 10000; i++) {
-    tasks.push(pool.runTask(null));
+    tasks.push(pool.run(null));
   }
 
   await Promise.all(tasks);

--- a/test/fixtures/console-log.ts
+++ b/test/fixtures/console-log.ts
@@ -6,4 +6,4 @@ const pool = new Piscina({
   maxThreads: 1
 });
 
-pool.runTask('console.log("A"); console.log("B");');
+pool.run('console.log("A"); console.log("B");');

--- a/test/histogram.ts
+++ b/test/histogram.ts
@@ -9,7 +9,7 @@ test('pool will maintain run and wait time histograms', async ({ equal, ok }) =>
 
   const tasks = [];
   for (let n = 0; n < 10; n++) {
-    tasks.push(pool.runTask('42'));
+    tasks.push(pool.run('42'));
   }
   await Promise.all(tasks);
 

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -17,8 +17,8 @@ test('idle timeout will let go of threads early', async ({ equal }) => {
   const buffer = new Int32Array(new SharedArrayBuffer(4));
 
   const firstTasks = [
-    pool.runTask([buffer, 2]),
-    pool.runTask([buffer, 2])
+    pool.run([buffer, 2]),
+    pool.run([buffer, 2])
   ];
   equal(pool.threads.length, 2);
 
@@ -29,8 +29,8 @@ test('idle timeout will let go of threads early', async ({ equal }) => {
   equal(pool.threads.length, 1);
 
   const secondTasks = [
-    pool.runTask([buffer, 4]),
-    pool.runTask([buffer, 4])
+    pool.run([buffer, 4]),
+    pool.run([buffer, 4])
   ];
   equal(pool.threads.length, 2);
 

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -10,7 +10,7 @@ test('Pool receive message from workers', async ({ equal }) => {
 
   const messagePromise = once(pool, 'message');
 
-  const taskResult = pool.runTask(`
+  const taskResult = pool.run(`
         require('worker_threads').parentPort.postMessage("some message");
         42
     `);

--- a/test/move-test.ts
+++ b/test/move-test.ts
@@ -75,21 +75,6 @@ test('Moving works', async ({ equal, ok }) => {
   });
 
   {
-    const ab = new ArrayBuffer(10);
-    const ret = await pool.runTask(Piscina.move(ab));
-    equal(ab.byteLength, 0); // It was moved
-    ok(types.isAnyArrayBuffer(ret));
-  }
-
-  {
-    // Test with empty transferList
-    const ab = new ArrayBuffer(10);
-    const ret = await pool.runTask(Piscina.move(ab), []);
-    equal(ab.byteLength, 0); // It was moved
-    ok(types.isAnyArrayBuffer(ret));
-  }
-
-  {
     // Test with empty transferList
     const ab = new ArrayBuffer(10);
     const ret = await pool.run(Piscina.move(ab));

--- a/test/nice.ts
+++ b/test/nice.ts
@@ -13,7 +13,7 @@ test('can set niceness for threads on Linux', {
   // ts-ignore because the dependency is not installed on Windows.
   // @ts-ignore
   const currentNiceness = (await import('nice-napi')).default(0);
-  const result = await worker.runTask('require("nice-napi")()');
+  const result = await worker.run('require("nice-napi")()');
 
   // niceness is capped to 19 on Linux.
   const expected = Math.min(currentNiceness + 5, 19);
@@ -26,6 +26,6 @@ test('setting niceness never does anything bad', async ({ equal }) => {
     niceIncrement: 5
   });
 
-  const result = await worker.runTask('42');
+  const result = await worker.run('42');
   equal(result, 42);
 });

--- a/test/pool-destroy.ts
+++ b/test/pool-destroy.ts
@@ -7,5 +7,5 @@ test('can destroy pool while tasks are running', async ({ rejects }) => {
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   setImmediate(() => pool.destroy());
-  await rejects(pool.runTask('while(1){}'), /Terminating worker thread/);
+  await rejects(pool.run('while(1){}'), /Terminating worker thread/);
 });

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -10,17 +10,6 @@ test('postTask() can transfer ArrayBuffer instances', async ({ equal }) => {
   });
 
   const ab = new ArrayBuffer(40);
-  await pool.runTask({ ab }, [ab]);
-  equal(pool.completed, 1);
-  equal(ab.byteLength, 0);
-});
-
-test('postTask() can transfer ArrayBuffer instances', async ({ equal }) => {
-  const pool = new Piscina({
-    filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
-  });
-
-  const ab = new ArrayBuffer(40);
   await pool.run({ ab }, { transferList: [ab] });
   equal(pool.completed, 1);
   equal(ab.byteLength, 0);
@@ -32,7 +21,7 @@ test('postTask() cannot clone build-in objects', async ({ rejects }) => {
   });
 
   const obj = new MessageChannel().port1;
-  rejects(pool.runTask({ obj }));
+  rejects(pool.run({ obj }));
 });
 
 test('postTask() resolves with a rejection when the handler rejects', async ({ rejects }) => {
@@ -40,7 +29,7 @@ test('postTask() resolves with a rejection when the handler rejects', async ({ r
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  rejects(pool.runTask('Promise.reject(new Error("foo"))'), /foo/);
+  rejects(pool.run('Promise.reject(new Error("foo"))'), /foo/);
 });
 
 test('postTask() resolves with a rejection when the handler throws', async ({ rejects }) => {
@@ -48,16 +37,13 @@ test('postTask() resolves with a rejection when the handler throws', async ({ re
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  rejects(pool.runTask('throw new Error("foo")'), /foo/);
+  rejects(pool.run('throw new Error("foo")'), /foo/);
 });
 
 test('postTask() validates transferList', async ({ rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-
-  rejects(pool.runTask('0', 42 as any),
-    /transferList argument must be an Array/);
 
   rejects(pool.run('0', { transferList: 42 as any }),
     /transferList argument must be an Array/);
@@ -67,9 +53,6 @@ test('postTask() validates filename', async ({ rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-
-  rejects(pool.runTask('0', [], 42 as any),
-    /filename argument must be a string/);
 
   rejects(pool.run('0', { filename: 42 as any }),
     /filename argument must be a string/);
@@ -89,9 +72,6 @@ test('postTask() validates abortSignal', async ({ rejects }) => {
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  rejects(pool.runTask('0', [], undefined, 42 as any),
-    /signal argument must be an object/);
-
   rejects(pool.run('0', { signal: 42 as any }),
     /signal argument must be an object/);
 });
@@ -109,7 +89,7 @@ test('Piscina emits drain', async ({ ok, notOk }) => {
     needsDrain = pool.needsDrain;
   });
 
-  await Promise.all([pool.runTask('123'), pool.runTask('123'), pool.runTask('123')]);
+  await Promise.all([pool.run('123'), pool.run('123'), pool.run('123')]);
 
   ok(drained);
   notOk(needsDrain);
@@ -145,14 +125,14 @@ test('Piscina can use async loaded workers', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-async.js')
   });
-  equal(await pool.runTask('1'), 1);
+  equal(await pool.run('1'), { transferList: 1 });
 });
 
 test('Piscina can use async loaded esm workers', {}, async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/esm-async.mjs')
   });
-  equal(await pool.runTask('1'), 1);
+  equal(await pool.run('1'), { tranferList: 1 });
 });
 
 test('Piscina.run options is correct type', async ({ rejects }) => {

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -21,7 +21,7 @@ test('Piscina.isWorkerThread has the correct value (worker)', async ({ equal }) 
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
-  const result = await worker.runTask(null);
+  const result = await worker.run(null);
   equal(result, 'done');
 });
 
@@ -46,7 +46,7 @@ test('trivial eval() handler works', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-  const result = await worker.runTask('42');
+  const result = await worker.run('42');
   equal(result, 42);
 });
 
@@ -54,29 +54,29 @@ test('async eval() handler works', async ({ equal }) => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-  const result = await worker.runTask('Promise.resolve(42)');
+  const result = await worker.run('Promise.resolve(42)');
   equal(result, 42);
 });
 
 test('filename can be provided while posting', async ({ equal }) => {
   const worker = new Piscina();
-  const result = await worker.runTask(
+  const result = await worker.run(
     'Promise.resolve(42)',
-    resolve(__dirname, 'fixtures/eval.js'));
+    { filename: resolve(__dirname, 'fixtures/eval.js') });
   equal(result, 42);
 });
 
 test('filename can be null when initially provided', async ({ equal }) => {
   const worker = new Piscina({ filename: null });
-  const result = await worker.runTask(
+  const result = await worker.run(
     'Promise.resolve(42)',
-    resolve(__dirname, 'fixtures/eval.js'));
+    { filename: resolve(__dirname, 'fixtures/eval.js') });
   equal(result, 42);
 });
 
 test('filename must be provided while posting', async ({ rejects }) => {
   const worker = new Piscina();
-  rejects(worker.runTask('doesn’t matter'),
+  rejects(worker.run('doesn’t matter'),
     /filename must be provided to run\(\) or in options object/);
 });
 
@@ -86,7 +86,7 @@ test('passing env to workers works', async ({ same }) => {
     env: { A: 'foo' }
   });
 
-  const env = await pool.runTask('({...process.env})');
+  const env = await pool.run('({...process.env})');
   same(env, { A: 'foo' });
 });
 
@@ -96,7 +96,7 @@ test('passing argv to workers works', async ({ same }) => {
     argv: ['a', 'b', 'c']
   });
 
-  const env = await pool.runTask('process.argv.slice(2)');
+  const env = await pool.run('process.argv.slice(2)');
   same(env, ['a', 'b', 'c']);
 });
 
@@ -106,7 +106,7 @@ test('passing execArgv to workers works', async ({ same }) => {
     execArgv: ['--no-warnings']
   });
 
-  const env = await pool.runTask('process.execArgv');
+  const env = await pool.run('process.execArgv');
   same(env, ['--no-warnings']);
 });
 
@@ -117,7 +117,7 @@ test('passing valid workerData works', async ({ equal }) => {
   });
   equal(Piscina.workerData, undefined);
 
-  await pool.runTask(null);
+  await pool.run(null);
 });
 
 test('passing invalid workerData does not work', async ({ throws }) => {
@@ -133,7 +133,7 @@ test('filename can be a file:// URL', async ({ equal }) => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')).href
   });
-  const result = await worker.runTask('42');
+  const result = await worker.run('42');
   equal(result, 42);
 });
 
@@ -141,7 +141,7 @@ test('filename can be a file:// URL to an ESM module', {}, async ({ equal }) => 
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')).href
   });
-  const result = await worker.runTask('42');
+  const result = await worker.run('42');
   equal(result, 42);
 });
 
@@ -154,9 +154,9 @@ test('duration and utilization calculations work', async ({ equal, ok }) => {
   equal(worker.utilization, 0);
 
   await Promise.all([
-    worker.runTask('42'),
-    worker.runTask('41'),
-    worker.runTask('40')
+    worker.run('42'),
+    worker.run('41'),
+    worker.run('40')
   ]);
 
   // utilization is going to be some non-deterministic value

--- a/test/task-queue.ts
+++ b/test/task-queue.ts
@@ -22,19 +22,19 @@ test('will put items into a task queue until they can run', async ({ equal }) =>
 
   const results = [];
 
-  results.push(pool.runTask(buffers[0]));
+  results.push(pool.run(buffers[0]));
   equal(pool.threads.length, 2);
   equal(pool.queueSize, 0);
 
-  results.push(pool.runTask(buffers[1]));
+  results.push(pool.run(buffers[1]));
   equal(pool.threads.length, 2);
   equal(pool.queueSize, 0);
 
-  results.push(pool.runTask(buffers[2]));
+  results.push(pool.run(buffers[2]));
   equal(pool.threads.length, 3);
   equal(pool.queueSize, 0);
 
-  results.push(pool.runTask(buffers[3]));
+  results.push(pool.run(buffers[3]));
   equal(pool.threads.length, 3);
   equal(pool.queueSize, 1);
 
@@ -60,19 +60,19 @@ test('will reject items over task queue limit', async ({ equal, rejects }) => {
   equal(pool.threads.length, 0);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
+  rejects(pool.run('while (true) {}'), /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
+  rejects(pool.run('while (true) {}'), /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 1);
 
-  rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
+  rejects(pool.run('while (true) {}'), /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 2);
 
-  rejects(pool.runTask('while (true) {}'), /Task queue is at limit/);
+  rejects(pool.run('while (true) {}'), /Task queue is at limit/);
   await pool.destroy();
 });
 
@@ -87,11 +87,11 @@ test('will reject items when task queue is unavailable', async ({ equal, rejects
   equal(pool.threads.length, 0);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
+  rejects(pool.run('while (true) {}'), /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /No task queue available and all Workers are busy/);
+  rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
@@ -106,11 +106,11 @@ test('will reject items when task queue is unavailable (fixed thread count)', as
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /Terminating worker thread/);
+  rejects(pool.run('while (true) {}'), /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask('while (true) {}'), /No task queue available and all Workers are busy/);
+  rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
@@ -126,11 +126,11 @@ test('tasks can share a Worker if requested (both tests blocking)', async ({ equ
   equal(pool.threads.length, 0);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask(new Int32Array(new SharedArrayBuffer(4))));
+  rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask(new Int32Array(new SharedArrayBuffer(4))));
+  rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
@@ -154,13 +154,14 @@ test('tasks can share a Worker if requested (one test finishes)', async ({ equal
   equal(pool.threads.length, 0);
   equal(pool.queueSize, 0);
 
-  const firstTask = pool.runTask(buffers[0]);
+  const firstTask = pool.run(buffers[0]);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  rejects(pool.runTask(
+  rejects(pool.run(
     'new Promise((resolve) => setTimeout(resolve, 1000000))',
-    resolve(__dirname, 'fixtures/eval.js')), /Terminating worker thread/);
+    { filename: resolve(__dirname, 'fixtures/eval.js') })
+  , /Terminating worker thread/);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
@@ -191,11 +192,11 @@ test('tasks can share a Worker if requested (both tests finish)', async ({ equal
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  const firstTask = pool.runTask(buffers[0]);
+  const firstTask = pool.run(buffers[0]);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
-  const secondTask = pool.runTask(buffers[1]);
+  const secondTask = pool.run(buffers[1]);
   equal(pool.threads.length, 1);
   equal(pool.queueSize, 0);
 
@@ -265,9 +266,9 @@ test('custom task queue works', async ({ equal, ok }) => {
   }
 
   const ret = await Promise.all([
-    pool.runTask(makeTask({ a: 1 }, 1)),
-    pool.runTask(makeTask({ a: 2 }, 2)),
-    pool.runTask({ a: 3 }) // No queueOptionsSymbol attached
+    pool.run(makeTask({ a: 1 }, 1)),
+    pool.run(makeTask({ a: 2 }, 2)),
+    pool.run({ a: 3 }) // No queueOptionsSymbol attached
   ]);
 
   equal(ret[0].a, 1);

--- a/test/test-resourcelimits.ts
+++ b/test/test-resourcelimits.ts
@@ -29,6 +29,6 @@ test('resourceLimits causes task to reject', async ({ equal, rejects }) => {
   equal(limits.maxOldGenerationSizeMb, 16);
   equal(limits.maxYoungGenerationSizeMb, 4);
   equal(limits.codeRangeSizeMb, 16);
-  rejects(worker.runTask(null),
+  rejects(worker.run(null),
     /Worker terminated due to reaching memory limit: JS heap out of memory/);
 });

--- a/test/test-uncaught-exception-from-handler.ts
+++ b/test/test-uncaught-exception-from-handler.ts
@@ -7,7 +7,7 @@ test('uncaught exception resets Worker', async ({ rejects }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-  await rejects(pool.runTask('throw new Error("not_caught")'), /not_caught/);
+  await rejects(pool.run('throw new Error("not_caught")'), /not_caught/);
 });
 
 test('uncaught exception in immediate resets Worker', async ({ rejects }) => {
@@ -15,7 +15,7 @@ test('uncaught exception in immediate resets Worker', async ({ rejects }) => {
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   await rejects(
-    pool.runTask(`
+    pool.run(`
       setImmediate(() => { throw new Error("not_caught") });
       new Promise(() => {}) /* act as if we were doing some work */
     `), /not_caught/);
@@ -30,7 +30,7 @@ test('uncaught exception in immediate after task yields error event', async ({ e
 
   const errorEvent : Promise<Error[]> = once(pool, 'error');
 
-  const taskResult = pool.runTask(`
+  const taskResult = pool.run(`
     setTimeout(() => { throw new Error("not_caught") }, 500);
     42
   `);
@@ -51,7 +51,7 @@ test('exiting process resets worker', async ({ not, rejects }) => {
     minThreads: 1
   });
   const originalThreadId = pool.threads[0].threadId;
-  await rejects(pool.runTask('process.exit(1);'), /worker exited with code: 1/);
+  await rejects(pool.run('process.exit(1);'), /worker exited with code: 1/);
   const newThreadId = pool.threads[0].threadId;
   not(originalThreadId, newThreadId);
 });
@@ -63,13 +63,13 @@ test('exiting process in immediate after task errors next task and resets worker
   });
 
   const originalThreadId = pool.threads[0].threadId;
-  const taskResult = await pool.runTask(`
+  const taskResult = await pool.run(`
     setTimeout(() => { process.exit(1); }, 50);
     42
   `);
   equal(taskResult, 42);
 
-  await rejects(pool.runTask(`
+  await rejects(pool.run(`
   'use strict';
 
   const { promisify } = require('util');

--- a/test/thread-count.ts
+++ b/test/thread-count.ts
@@ -10,15 +10,15 @@ test('will start with minThreads and max out at maxThreads', async ({ equal, rej
     maxThreads: 4
   });
   equal(pool.threads.length, 2);
-  rejects(pool.runTask('while(true) {}'));
+  rejects(pool.run('while(true) {}'));
   equal(pool.threads.length, 2);
-  rejects(pool.runTask('while(true) {}'));
+  rejects(pool.run('while(true) {}'));
   equal(pool.threads.length, 2);
-  rejects(pool.runTask('while(true) {}'));
+  rejects(pool.run('while(true) {}'));
   equal(pool.threads.length, 3);
-  rejects(pool.runTask('while(true) {}'));
+  rejects(pool.run('while(true) {}'));
   equal(pool.threads.length, 4);
-  rejects(pool.runTask('while(true) {}'));
+  rejects(pool.run('while(true) {}'));
   equal(pool.threads.length, 4);
   await pool.destroy();
 });


### PR DESCRIPTION
## Context
The PR attempts to drop the `runTask` method signature as part of the new `v5` work.

## Changes
- refactor: replace abortcontroller lib with native
- refactor!: remove deprecated runTask method
