### PR TITLE
refactor: emit `drain` as soon as capacity is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,8 @@ itself.
 
 ### Event: `'drain'`
 
-A `'drain'` event is emitted whenever the `queueSize` reaches `0`.
+A `'drain'` event is emitted whenever the `queueSize` is below the
+total capacity of the pool.
 
 ### Event: `'needsDrain'`
 

--- a/README.md
+++ b/README.md
@@ -434,8 +434,11 @@ itself.
 
 ### Event: `'drain'`
 
-A `'drain'` event is emitted whenever the `queueSize` is below the
-total capacity of the pool.
+A `'drain'` event is emitted when the current usage of the
+pool is below the maximum capacity of the same.
+The intended goal is to provide backpressure to the task source
+so creating tasks that can not be executed at immediately can be avoided.
+
 
 ### Event: `'needsDrain'`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -526,6 +526,7 @@ class ThreadPool {
   inProcessPendingMessages : boolean = false;
   startingUp : boolean = false;
   workerFailsDuringBootstrap : boolean = false;
+  checkpointStatus: boolean = true;
 
   constructor (publicInterface : Piscina, options : Options) {
     this.publicInterface = publicInterface;
@@ -883,9 +884,30 @@ class ThreadPool {
     const totalCapacity = this.options.maxQueue + this.pendingCapacity();
     const totalQueueSize = this.taskQueue.size + this.skipQueue.length;
 
-    if (totalQueueSize === 0) {
-      this.needsDrain = false;
+    /**
+     * The rationale is to checkpoint the capacity every time new
+     * task is being schedulded or appended to the queue.
+     * If capacity exceeded but we having checkpointed yet the check,
+     * we allow the pool to see if it can flush itself soon.
+     *
+     * At subsequent checks, we verify that the previously checkpoint
+     * was negative, and its current capacity. If the capacity excheded
+     * and previous checkpoint was negative, and the capacity is above
+     * the workload, we emit the drain event.
+     *
+     * If previous checkpoint is false, but the capacity stills exceeded,
+     * we checkpoint as false, and wait for a further checkpoint to validate
+     * once more the checks.
+     */
+    const isCapacityExceeded = totalQueueSize >= totalCapacity;
+    const shouldEmitDrain = !isCapacityExceeded && !this.checkpointStatus;
+
+    if (shouldEmitDrain) {
       this.publicInterface.emit('drain');
+    } else if (isCapacityExceeded) {
+      this.checkpointStatus = false;
+    } else {
+      this.checkpointStatus = true;
     }
 
     if (totalQueueSize >= totalCapacity) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,7 +380,7 @@ class AsynchronouslyCreatedResourcePool<
     for (const worker of this.readyItems) {
       const currentUsage = worker.currentUsage();
 
-      if (currentUsage < Infinity) inFlight += currentUsage;
+      if (Number.isFinite(currentUsage)) inFlight += currentUsage;
     }
 
     return inFlight;

--- a/src/index.ts
+++ b/src/index.ts
@@ -537,6 +537,7 @@ class ThreadPool {
   inProcessPendingMessages : boolean = false;
   startingUp : boolean = false;
   workerFailsDuringBootstrap : boolean = false;
+  maxCapacity: number;
 
   constructor (publicInterface : Piscina, options : Options) {
     this.publicInterface = publicInterface;
@@ -565,6 +566,7 @@ class ThreadPool {
     this.workers = new AsynchronouslyCreatedResourcePool<WorkerInfo>(
       this.options.concurrentTasksPerWorker);
     this.workers.onAvailable((w : WorkerInfo) => this._onWorkerAvailable(w));
+    this.maxCapacity = this.options.maxThreads * this.options.concurrentTasksPerWorker;
 
     this.startingUp = true;
     this._ensureMinimumWorkers();
@@ -896,7 +898,7 @@ class ThreadPool {
      * in a way where always waiting === 0, since we want to avoid creating tasks that can't execute
      * immediately in order to provide back pressure to the task source.
      */
-    const maxCapacity = this.options.maxThreads * this.options.concurrentTasksPerWorker;
+    const { maxCapacity } = this;
     const currentUsage = this.workers.getCurrentUsage();
 
     if (maxCapacity === currentUsage) {

--- a/test/post-task.ts
+++ b/test/post-task.ts
@@ -98,7 +98,8 @@ test('postTask() validates abortSignal', async ({ rejects }) => {
 
 test('Piscina emits drain', async ({ ok, notOk }) => {
   const pool = new Piscina({
-    filename: resolve(__dirname, 'fixtures/eval.js')
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    maxThreads: 1
   });
 
   let drained = false;
@@ -108,7 +109,7 @@ test('Piscina emits drain', async ({ ok, notOk }) => {
     needsDrain = pool.needsDrain;
   });
 
-  await Promise.all([pool.run('123'), pool.run('123')]);
+  await Promise.all([pool.runTask('123'), pool.runTask('123'), pool.runTask('123')]);
 
   ok(drained);
   notOk(needsDrain);


### PR DESCRIPTION
Implements insights from #126.

The new rationale to emit `drain` event, goes as follows:

>The rationale is to checkpoint the capacity every time new
>task is being schedulded or appended to the queue.
>If capacity exceeded but we having checkpointed yet the check,
>we allow the pool to see if it can flush itself soon.
>
>At subsequent checks, we verify that the previously checkpoint
>was negative, and its current capacity. If the capacity excheded
>and previous checkpoint was negative, and the capacity is above
>the workload, we emit the drain event.
>
>If previous checkpoint is false, but the capacity stills exceeded,
>we checkpoint as false, and wait for a further checkpoint to validate
>once more the checks.