### PR TITLE
fix: use CJS imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { Worker, MessageChannel, MessagePort, receiveMessageOnPort } from 'worker_threads';
 import { once } from 'events';
-import EventEmitterAsyncResource from 'eventemitter-asyncresource';
+import EventEmitterAsyncResource = require('eventemitter-asyncresource');
 import { AsyncResource } from 'async_hooks';
 import { cpus } from 'os';
 import { fileURLToPath, URL } from 'url';
 import { resolve } from 'path';
 import { inspect, types } from 'util';
-import assert from 'assert';
+import assert = require('assert');
 import { Histogram, build } from 'hdr-histogram-js';
 import { performance } from 'perf_hooks';
 import hdrobj from 'hdr-histogram-percentiles-obj';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { cpus } from 'os';
 import { fileURLToPath, URL } from 'url';
 import { resolve } from 'path';
 import { inspect, types } from 'util';
-import assert = require('assert');
+import assert from 'assert';
 import { Histogram, build } from 'hdr-histogram-js';
 import { performance } from 'perf_hooks';
 import hdrobj from 'hdr-histogram-percentiles-obj';


### PR DESCRIPTION
The `eventemitter-asyncresource` import only works due to using `esModuleInterop`. However, using this flag forces all downstream consumers to also use it, polluting the entire tree.

FWIW, this is the error I get attempting to use Piscina in a project that does not set the interop option.

<img width="1797" alt="image" src="https://github.com/piscinajs/piscina/assets/1404810/ae09cad0-f018-416a-aa7d-631dab803a90">