### PR TITLE
fix: do not re-create threads when calling `.destory()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,7 @@ class ThreadPool {
   startingUp : boolean = false;
   closingUp : boolean = false;
   workerFailsDuringBootstrap : boolean = false;
+  destroying : boolean = false;
 
   constructor (publicInterface : Piscina, options : Options) {
     this.publicInterface = publicInterface;
@@ -581,7 +582,7 @@ class ThreadPool {
   }
 
   _ensureMinimumWorkers () : void {
-    if (this.closingUp) {
+    if (this.closingUp || this.destroying) {
       return;
     }
     while (this.workers.size < this.options.minThreads) {
@@ -663,6 +664,10 @@ class ThreadPool {
     });
 
     worker.on('exit', (exitCode : number) => {
+      if (this.destroying) {
+        return;
+      }
+
       const err = new Error(`worker exited with code: ${exitCode}`);
       // Only error unfinished tasks on process exit, since there are legitimate
       // reasons to exit workers and we want to handle that gracefully when possible.
@@ -926,6 +931,7 @@ class ThreadPool {
   }
 
   async destroy () {
+    this.destroying = true;
     while (this.skipQueue.length > 0) {
       const taskInfo : TaskInfo = this.skipQueue.shift() as TaskInfo;
       taskInfo.done(new Error('Terminating worker thread'));
@@ -942,7 +948,11 @@ class ThreadPool {
       this._removeWorker(workerInfo);
     }
 
-    await Promise.all(exitEvents);
+    try {
+      await Promise.all(exitEvents);
+    } finally {
+      this.destroying = false;
+    }
   }
 
   async close (options : Required<CloseOptions>) {

--- a/test/thread-count.ts
+++ b/test/thread-count.ts
@@ -51,3 +51,14 @@ test('conflicting min/max threads is error', async ({ throws }) => {
     maxThreads: 8
   }), /options.minThreads and options.maxThreads must not conflict/);
 });
+
+test('thread count should be 0 upon destruction', async ({ equal }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    minThreads: 2,
+    maxThreads: 4
+  });
+  equal(pool.threads.length, 2);
+  await pool.destroy();
+  equal(pool.threads.length, 0);
+});


### PR DESCRIPTION
https://github.com/piscinajs/piscina/commit/8e6d16e1dc23f8bb39772ed954f6689852ad435f caused a regression that upon calling `.destroy` the threads works would be destoryed and re-created.

This is because, when calling [`worker.terminate()`](https://github.com/piscinajs/piscina/blob/f99f9810ec2fd680b9274bc43b91824fd961afee/src/index.ts#L435) the worker will exit with a status code of 1. This causes the [`_onError`](https://github.com/piscinajs/piscina/blob/f99f9810ec2fd680b9274bc43b91824fd961afee/src/index.ts#L669) method to be called which under subsequently calls  [`ensureMinimWorkers`](https://github.com/piscinajs/piscina/blob/f99f9810ec2fd680b9274bc43b91824fd961afee/src/index.ts#L695)

Closes #427