### PR TITLE
fix: migrate to EventEmitterAsyncResource from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.8.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.0",
+    "@typescript-eslint/parser": "^6.9.0",
     "abort-controller": "^3.0.0",
     "concat-stream": "^2.0.0",
     "gen-esm-wrapper": "^1.1.1",
@@ -44,7 +44,7 @@
     "standardx": "^7.0.0",
     "tap": "^16.3.7",
     "ts-node": "^9.1.1",
-    "typescript": "5.2.x"
+    "typescript": "5.1.6"
   },
   "dependencies": {
     "hdr-histogram-js": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^20.3.3",
+    "@types/node": "^20.8.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "abort-controller": "^3.0.0",
@@ -44,10 +44,9 @@
     "standardx": "^7.0.0",
     "tap": "^16.3.7",
     "ts-node": "^9.1.1",
-    "typescript": "4.3.x"
+    "typescript": "5.2.x"
   },
   "dependencies": {
-    "eventemitter-asyncresource": "^1.0.0",
     "hdr-histogram-js": "^2.0.1",
     "hdr-histogram-percentiles-obj": "^3.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Worker, MessageChannel, MessagePort, receiveMessageOnPort } from 'worker_threads';
-import { once } from 'events';
-import EventEmitterAsyncResource = require('eventemitter-asyncresource');
+import { once, EventEmitterAsyncResource } from 'events';
 import { AsyncResource } from 'async_hooks';
 import { cpus } from 'os';
 import { fileURLToPath, URL } from 'url';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -172,7 +172,7 @@ function onMessage (
         result: null,
         // It may be worth taking a look at the error cloning algorithm we
         // use in Node.js core here, it's quite a bit more flexible
-        error
+        error: error instanceof Error ? error : null
       };
     }
     currentTasks--;


### PR DESCRIPTION
Fixes: #426

- Updated the types definitions to include `EventEmitterAsyncResource`
- Removed external package for `EventEmitterAsyncResource`
- Updated typescript to v5 - needed for the type definitions 
- Fixed type errors after upgrade to ts v5

Note: I guess this loses the compatibility with node versions prior to inclusion of `EventEmitterAsyncResource`