### PR TITLE
chore: Improve package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.github
-.nyc_output
-package-lock.json
-coverage
-examples

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "import": "./dist/esm-wrapper.mjs",
     "require": "./dist/src/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc && gen-esm-wrapper . dist/esm-wrapper.mjs",


### PR DESCRIPTION
Include only relevant files in the bundle, everything else is skipped from the shipped NPM package.

Before: 424 KB
After: 164 KB

`.npmignore` is no longer needed, allowed files are controlled via [files](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) option in `package.json`.
