### PR TITLE
fix: default minThreads with odd CPU count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ interface FilledOptions extends Options {
 const kDefaultOptions : FilledOptions = {
   filename: null,
   name: 'default',
-  minThreads: Math.max(cpuCount / 2, 1),
+  minThreads: Math.max(Math.floor(cpuCount / 2), 1),
   maxThreads: cpuCount * 1.5,
   idleTimeout: 0,
   maxQueue: Infinity,


### PR DESCRIPTION
If not, Piscina will create and remove the latest worker indefinitely

Because of https://github.com/piscinajs/piscina/blob/current/src/index.ts#L587 and https://github.com/piscinajs/piscina/blob/current/src/index.ts#L762