### PR TITLE
fix(#513): forward errors correctly to Piscina

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -172,7 +172,7 @@ function onMessage (
         result: null,
         // It may be worth taking a look at the error cloning algorithm we
         // use in Node.js core here, it's quite a bit more flexible
-        error: error instanceof Error ? error : null
+        error: <Error>error
       };
     }
     currentTasks--;

--- a/test/fixtures/vm.js
+++ b/test/fixtures/vm.js
@@ -1,0 +1,7 @@
+// worker.js
+const vm = require('vm');
+
+module.exports = ({ payload, context }) => {
+  const script = new vm.Script(payload);
+  script.runInNewContext(context);
+};

--- a/test/issue-513.ts
+++ b/test/issue-513.ts
@@ -4,10 +4,10 @@ import { resolve } from 'path';
 
 test('pool will maintain run and wait time histograms', async ({
   equal,
-  fail,
+  fail
 }) => {
   const pool = new Piscina({
-    filename: resolve(__dirname, 'fixtures/vm.js'),
+    filename: resolve(__dirname, 'fixtures/vm.js')
   });
 
   try {

--- a/test/issue-513.ts
+++ b/test/issue-513.ts
@@ -1,0 +1,19 @@
+import Piscina from '..';
+import { test } from 'tap';
+import { resolve } from 'path';
+
+test('pool will maintain run and wait time histograms', async ({
+  equal,
+  fail,
+}) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/vm.js'),
+  });
+
+  try {
+    await pool.run({ payload: 'throw new Error("foo")' });
+    fail('Expected an error');
+  } catch (error) {
+    equal(error.message, 'foo');
+  }
+});


### PR DESCRIPTION
### Changes

- **fix: forward error correctly**

### Rationale

With the migration to `EventEmitterAsyncResource` we changed the way we forwarded the errors and do an instance check; which as the errors thrown by VM are not instances of `Error` we were not forwarding them correctly.