### PR TITLE
feat: allow named import usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "piscina",
   "version": "4.3.2",
   "description": "A fast, efficient Node.js Worker Thread Pool implementation",
-  "main": "./dist/src/index.js",
+  "main": "./dist/src/main.js",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "import": "./dist/esm-wrapper.mjs",
-    "require": "./dist/src/index.js"
+    "require": "./dist/src/main.js"
   },
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1074,7 +1074,7 @@ class ThreadPool {
   }
 }
 
-class Piscina extends EventEmitterAsyncResource {
+export default class Piscina extends EventEmitterAsyncResource {
   #pool : ThreadPool;
 
   constructor (options : Options = {}) {
@@ -1346,4 +1346,14 @@ class Piscina extends EventEmitterAsyncResource {
   static get queueOptionsSymbol () { return kQueueOptions; }
 }
 
-export = Piscina;
+export const move = Piscina.move;
+export const isWorkerThread = Piscina.isWorkerThread;
+export const workerData = Piscina.workerData;
+
+export {
+  Piscina,
+  kTransferable as transferableSymbol,
+  kValue as valueSymbol,
+  kQueueOptions as queueOptionsSymbol,
+  version
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import Piscina from './index';
+
+// Used as the require() entry point to maintain existing behavior
+export = Piscina;

--- a/test/fixtures/simple-isworkerthread-named-import.ts
+++ b/test/fixtures/simple-isworkerthread-named-import.ts
@@ -1,0 +1,6 @@
+import { isWorkerThread } from '../..';
+import assert from 'assert';
+
+assert.strictEqual(isWorkerThread, true);
+
+export default function () { return 'done'; }

--- a/test/fixtures/simple-workerdata-named-import.ts
+++ b/test/fixtures/simple-workerdata-named-import.ts
@@ -1,0 +1,6 @@
+import { workerData } from '../..';
+import assert from 'assert';
+
+assert.strictEqual(workerData, 'ABC');
+
+export default function () { return 'done'; }

--- a/test/simple-test.ts
+++ b/test/simple-test.ts
@@ -25,6 +25,14 @@ test('Piscina.isWorkerThread has the correct value (worker)', async ({ equal }) 
   equal(result, 'done');
 });
 
+test('Piscina.isWorkerThread has the correct value (worker) with named import', async ({ equal }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/simple-isworkerthread-named-import.ts')
+  });
+  const result = await worker.runTask(null);
+  equal(result, 'done');
+});
+
 test('Piscina instance is an EventEmitter', async ({ ok }) => {
   const piscina = new Piscina();
   ok(piscina instanceof EventEmitter);
@@ -113,6 +121,16 @@ test('passing execArgv to workers works', async ({ same }) => {
 test('passing valid workerData works', async ({ equal }) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
+    workerData: 'ABC'
+  });
+  equal(Piscina.workerData, undefined);
+
+  await pool.runTask(null);
+});
+
+test('passing valid workerData works with named import', async ({ equal }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/simple-workerdata-named-import.ts'),
     workerData: 'ABC'
   });
   equal(Piscina.workerData, undefined);


### PR DESCRIPTION
The main exports of the package are now available both as named exports from the package as well as the previously available properties from the default export. This removes the requirement to use the `esModuleInterop` TypeScript option but retains backward compatiblity for existing usage.