### PR TITLE
docs: Replace third-party AbortController usage with native one in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ an `EventEmitter`:
 'use strict';
 
 const Piscina = require('piscina');
-const { AbortController } = require('abort-controller');
 const { resolve } = require('path');
 
 const piscina = new Piscina({
@@ -148,12 +147,6 @@ const piscina = new Piscina({
   }
 })();
 ```
-
-To use `AbortController`, you will need to `npm i abort-controller`
-(or `yarn add abort-controller`).
-
-(In Node.js 15.0.0 or higher, there is a new built-in `AbortController`
-implementation that can be used here as well.)
 
 Alternatively, any `EventEmitter` that emits an `'abort'` event
 may be used as an abort controller:


### PR DESCRIPTION
Given that the Readme specifies Piscina supports Node 16+, there is no longer a need to utilize a third-party `AbortController` implementation in the example.