### PR TITLE
feat: Use fixed queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ for (let i = 0; i < 10; i++) {
   });
 }
 ```
-In this example, we import `FixedQueue` from the `piscina` package and use it as the `taskQueue` option when creating a new Piscina pool. This allows users to take advantage of the performance improvements offered by `FixedQueue` before it becomes the default task queue implementation.
+**Note** The `FixedQueue` will become the default task queue implementation in a next major version.
 
 ## Current Limitations (Things we're working on / would love help with)
 

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ In terms of Piscina performance itself, using `FixedQueue` with a queue size of 
 Users can import `FixedQueue` from the `Piscina` package and pass it as the `taskQueue` option to leverage its benefits.
 
 
-### Using FixedQueue Example
+#### Using FixedQueue Example
 
 Here's an example of how to use the `FixedQueue`:
 

--- a/README.md
+++ b/README.md
@@ -702,6 +702,56 @@ options on to the custom `TaskQueue` implementation. (Note that because the
 queue options are set as a property on the task, tasks with queue
 options cannot be submitted as JavaScript primitives).
 
+**New:** As of the next major release, Piscina introduces the `FixedQueue`, a more performant task queue implementation based on [`FixedQueue`](https://github.com/nodejs/node/blob/de7b37880f5a541d5f874c1c2362a65a4be76cd0/lib/internal/fixed_queue.js) from Node.Js project.  
+
+Here are some benchmarks to compare new `FixedQueue` with `ArrayTaskQueue` (current default). The benchmarks demonstrate substantial improvements in push and shift operations, especially with larger queue sizes.
+```
+Queue size = 1000
+┌─────────┬─────────────────────────────────────────┬───────────┬────────────────────┬──────────┬─────────┐
+│ (index) │ Task Name                               │ ops/sec   │ Average Time (ns)  │ Margin   │ Samples │
+├─────────┼─────────────────────────────────────────┼───────────┼────────────────────┼──────────┼─────────┤
+│ 0       │ 'ArrayTaskQueue full push + full shift' │ '9 692'   │ 103175.15463917515 │ '±0.80%' │ 970     │
+│ 1       │ 'FixedQueue  full push + full shift'    │ '131 879' │ 7582.696390658352  │ '±1.81%' │ 13188   │
+└─────────┴─────────────────────────────────────────┴───────────┴────────────────────┴──────────┴─────────┘
+
+Queue size = 100_000
+┌─────────┬─────────────────────────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
+│ (index) │ Task Name                               │ ops/sec │ Average Time (ns)  │ Margin   │ Samples │
+├─────────┼─────────────────────────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
+│ 0       │ 'ArrayTaskQueue full push + full shift' │ '0'     │ 1162376920.0000002 │ '±1.77%' │ 10      │
+│ 1       │ 'FixedQueue full push + full shift'     │ '1 026' │ 974328.1553396407  │ '±2.51%' │ 103     │
+└─────────┴─────────────────────────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
+```
+In terms of Piscina performance itself, using `FixedQueue` with a queue size of 100,000 queued tasks can result in up to 6 times faster execution times.
+
+Users can import `FixedQueue` from the `Piscina` package and pass it as the `taskQueue` option to leverage its benefits.
+
+
+### Using FixedQueue Example
+
+Here's an example of how to use the `FixedQueue`:
+
+```js
+const { Piscina, FixedQueue } = require('piscina');
+const { resolve } = require('path');
+
+// Create a Piscina pool with FixedQueue
+const piscina = new Piscina({
+  filename: resolve(__dirname, 'worker.js'),
+  taskQueue: new FixedQueue()
+});
+
+// Submit tasks to the pool
+for (let i = 0; i < 10; i++) {
+  piscina.runTask({ data: i }).then((result) => {
+    console.log(result);
+  }).catch((error) => {
+    console.error(error);
+  });
+}
+```
+In this example, we import `FixedQueue` from the `piscina` package and use it as the `taskQueue` option when creating a new Piscina pool. This allows users to take advantage of the performance improvements offered by `FixedQueue` before it becomes the default task queue implementation.
+
 ## Current Limitations (Things we're working on / would love help with)
 
 * Improved Documentation

--- a/README.md
+++ b/README.md
@@ -702,7 +702,8 @@ options on to the custom `TaskQueue` implementation. (Note that because the
 queue options are set as a property on the task, tasks with queue
 options cannot be submitted as JavaScript primitives).
 
-**New:** As of the next major release, Piscina introduces the `FixedQueue`, a more performant task queue implementation based on [`FixedQueue`](https://github.com/nodejs/node/blob/de7b37880f5a541d5f874c1c2362a65a4be76cd0/lib/internal/fixed_queue.js) from Node.Js project.  
+### Built-In Queues
+Piscina also provides the `FixedQueue`, a more performant task queue implementation based on [`FixedQueue`](https://github.com/nodejs/node/blob/de7b37880f5a541d5f874c1c2362a65a4be76cd0/lib/internal/fixed_queue.js) from Node.js project.  
 
 Here are some benchmarks to compare new `FixedQueue` with `ArrayTaskQueue` (current default). The benchmarks demonstrate substantial improvements in push and shift operations, especially with larger queue sizes.
 ```

--- a/benchmark/piscina-queue-comparison.js
+++ b/benchmark/piscina-queue-comparison.js
@@ -1,0 +1,44 @@
+const { Bench } = require('tinybench');
+const FixedQeueue = require('../dist/src/fixed-queue').default;
+const { ArrayTaskQueue } = require('../dist/src/index');
+const { Piscina } = require('../dist/src');
+const { resolve } = require('node:path');
+
+const QUEUE_SIZE = 100_000;
+
+const bench = new Bench({ time: 100 });
+
+bench
+  .add('Piscina with ArrayTaskQueue', async () => {
+    const queue = new ArrayTaskQueue();
+    const pool = new Piscina({
+      filename: resolve(__dirname, 'fixtures/add.js'),
+      taskQueue: queue
+    });
+    const tasks = [];
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      tasks.push(pool.runTask({ a: 4, b: 6 }));
+    }
+    await Promise.all(tasks);
+    await pool.destroy();
+  })
+  .add('Piscina with FixedQueue', async () => {
+    const queue = new FixedQeueue();
+    const pool = new Piscina({
+      filename: resolve(__dirname, 'fixtures/add.js'),
+      taskQueue: queue
+    });
+    const tasks = [];
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      tasks.push(pool.runTask({ a: 4, b: 6 }));
+    }
+    await Promise.all(tasks);
+    await pool.destroy();
+  });
+
+(async () => {
+  await bench.warmup();
+  await bench.run();
+
+  console.table(bench.table());
+})();

--- a/benchmark/piscina-queue-comparison.js
+++ b/benchmark/piscina-queue-comparison.js
@@ -1,7 +1,5 @@
 const { Bench } = require('tinybench');
-const FixedQeueue = require('../dist/src/fixed-queue').default;
-const { ArrayTaskQueue } = require('../dist/src/index');
-const { Piscina } = require('../dist/src');
+const { Piscina, FixedQueue, ArrayTaskQueue } = require('..');
 const { resolve } = require('node:path');
 
 const QUEUE_SIZE = 100_000;
@@ -23,7 +21,7 @@ bench
     await pool.destroy();
   })
   .add('Piscina with FixedQueue', async () => {
-    const queue = new FixedQeueue();
+    const queue = new FixedQueue();
     const pool = new Piscina({
       filename: resolve(__dirname, 'fixtures/add.js'),
       taskQueue: queue

--- a/benchmark/queue-comparison.js
+++ b/benchmark/queue-comparison.js
@@ -1,0 +1,34 @@
+const { Bench } = require('tinybench');
+const FixedQeueue = require('../dist/src/fixed-queue').default;
+const { ArrayTaskQueue } = require('../dist/src/index');
+
+const QUEUE_SIZE = 100_000;
+
+const bench = new Bench({ time: 100 });
+
+bench
+  .add('ArrayTaskQueue full push + full shift', async () => {
+    const queue = new ArrayTaskQueue();
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      queue.push(i);
+    }
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      queue.shift();
+    }
+  })
+  .add('FixedQueue full push + full shift', async () => {
+    const queue = new FixedQeueue();
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      queue.push(i);
+    }
+    for (let i = 0; i < QUEUE_SIZE; i++) {
+      queue.shift();
+    }
+  });
+
+(async () => {
+  await bench.warmup();
+  await bench.run();
+
+  console.table(bench.table());
+})();

--- a/benchmark/queue-comparison.js
+++ b/benchmark/queue-comparison.js
@@ -1,6 +1,5 @@
 const { Bench } = require('tinybench');
-const FixedQeueue = require('../dist/src/fixed-queue').default;
-const { ArrayTaskQueue } = require('../dist/src/index');
+const { ArrayTaskQueue, FixedQueue } = require('..');
 
 const QUEUE_SIZE = 100_000;
 
@@ -17,7 +16,7 @@ bench
     }
   })
   .add('FixedQueue full push + full shift', async () => {
-    const queue = new FixedQeueue();
+    const queue = new FixedQueue();
     for (let i = 0; i < QUEUE_SIZE; i++) {
       queue.push(i);
     }

--- a/benchmark/simple-benchmark-2.js
+++ b/benchmark/simple-benchmark-2.js
@@ -1,0 +1,34 @@
+'use strict';
+const { Piscina } = require('../dist/src');
+const FixedQueue = require('../dist/src/fixed-queue').default;
+
+const { resolve } = require('path');
+
+async function simpleBenchmark ({ duration = 10000 } = {}) {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/add.js'),
+    taskQueue: new FixedQueue()
+  });
+  let done = 0;
+
+  const results = [];
+  const start = process.hrtime.bigint();
+  while (pool.queueSize === 0) {
+    results.push(scheduleTasks());
+  }
+
+  async function scheduleTasks () {
+    while ((process.hrtime.bigint() - start) / 1_000_000n < duration) {
+      await pool.runTask({ a: 4, b: 6 });
+      done++;
+    }
+  }
+
+  await Promise.all(results);
+
+  return done / duration * 1e3;
+}
+
+simpleBenchmark().then((opsPerSecond) => {
+  console.log(`opsPerSecond: ${opsPerSecond}`);
+});

--- a/benchmark/simple-benchmark-fixed-queue.js
+++ b/benchmark/simple-benchmark-fixed-queue.js
@@ -30,5 +30,5 @@ async function simpleBenchmark ({ duration = 10000 } = {}) {
 }
 
 simpleBenchmark().then((opsPerSecond) => {
-  console.log(`opsPerSecond: ${opsPerSecond}`);
+  console.log(`opsPerSecond: ${opsPerSecond} (with FixedQueue as taskQueue)`);
 });

--- a/benchmark/simple-benchmark-fixed-queue.js
+++ b/benchmark/simple-benchmark-fixed-queue.js
@@ -1,6 +1,5 @@
 'use strict';
-const { Piscina } = require('../dist/src');
-const FixedQueue = require('../dist/src/fixed-queue').default;
+const { Piscina, FixedQueue } = require('..');
 
 const { resolve } = require('path');
 

--- a/benchmark/simple-benchmark.js
+++ b/benchmark/simple-benchmark.js
@@ -25,5 +25,5 @@ async function simpleBenchmark ({ duration = 10000 } = {}) {
 }
 
 simpleBenchmark().then((opsPerSecond) => {
-  console.log(`opsPerSecond: ${opsPerSecond}`);
+  console.log(`opsPerSecond: ${opsPerSecond} (with default taskQueue)`);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "snazzy": "^9.0.0",
         "standardx": "^7.0.0",
         "tap": "^16.3.7",
+        "tinybench": "^2.8.0",
         "ts-node": "^10.9.2",
         "typescript": "5.4.5"
       },
@@ -7587,6 +7588,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+      "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "snazzy": "^9.0.0",
         "standardx": "^7.0.0",
         "tap": "^16.3.7",
+        "tinybench": "^2.8.0",
         "ts-node": "^10.9.2",
         "typescript": "5.4.5"
       },
@@ -7773,6 +7774,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+      "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "test:ci": "npm run lint && npm run build && npm run test:coverage",
     "test:coverage": "c8 --reporter=lcov tap --cov",
     "prepack": "npm run build",
-    "bench": "npm run benchmark:piscina-default && npm run benchmark:piscina-fixed-queue && npm run benchmark:queue-comparison && npm run benchmark:piscina-comparison",
+    "bench": "npm run bench:taskqueue && npm run bench:piscina",
+    "bench:piscina": "npm run benchmark:piscina-default &&npm run benchmark:piscina-fixed-queue && npm run benchmark:piscina-comparison",
+    "bench:taskqueue": "npm run benchmark:queue-comparison",
     "benchmark:piscina-default": "node benchmark/simple-benchmark.js",
     "benchmark:piscina-fixed-queue": "node benchmark/simple-benchmark-fixed-queue.js",
-    "benchmark:queue-comparison": "node benchmark/queue-comparison.js",
-    "benchmark:piscina-comparison": "node benchmark/piscina-queue-comparison.js"
+    "benchmark:piscina-comparison": "node benchmark/piscina-queue-comparison.js",
+    "benchmark:queue-comparison": "node benchmark/queue-comparison.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "test": "c8 tap",
     "test:ci": "npm run lint && npm run build && npm run test:coverage",
     "test:coverage": "c8 --reporter=lcov tap --cov",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "bench": "npm run benchmark:piscina-default && npm run benchmark:piscina-fixed-queue && npm run benchmark:queue-comparison && npm run benchmark:piscina-comparison",
+    "benchmark:piscina-default": "node benchmark/simple-benchmark.js",
+    "benchmark:piscina-fixed-queue": "node benchmark/simple-benchmark-fixed-queue.js",
+    "benchmark:queue-comparison": "node benchmark/queue-comparison.js",
+    "benchmark:piscina-comparison": "node benchmark/piscina-queue-comparison.js"
   },
   "repository": {
     "type": "git",
@@ -44,6 +49,7 @@
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
     "tap": "^16.3.7",
+    "tinybench": "^2.8.0",
     "ts-node": "^10.9.2",
     "typescript": "5.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "test": "tap --ts",
     "test:ci": "npm run lint && npm run build && npm run test:coverage",
     "test:coverage": "tap --ts --cov --coverage-report=html --no-browser --no-check-coverage",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "bench": "npm run benchmark:piscina-default && npm run benchmark:piscina-fixed-queue && npm run benchmark:queue-comparison && npm run benchmark:piscina-comparison",
+    "benchmark:piscina-default": "node benchmark/simple-benchmark.js",
+    "benchmark:piscina-fixed-queue": "node benchmark/simple-benchmark-fixed-queue.js",
+    "benchmark:queue-comparison": "node benchmark/queue-comparison.js",
+    "benchmark:piscina-comparison": "node benchmark/piscina-queue-comparison.js"
   },
   "repository": {
     "type": "git",
@@ -43,10 +48,10 @@
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
     "tap": "^16.3.7",
+    "tinybench": "^2.8.0",
     "ts-node": "^10.9.2",
     "typescript": "5.4.5"
   },
-  "dependencies": {},
   "optionalDependencies": {
     "nice-napi": "^1.0.2"
   },

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -153,7 +153,7 @@ export default class FixedQueue implements TaskQueue {
   }
 
   remove (task: Task) {
-    let prev = null;
+    let prev: FixedCircularBuffer | null = null;
     let buffer = this.tail;
     while (true) {
       if (buffer.list.includes(task)) {
@@ -166,11 +166,17 @@ export default class FixedQueue implements TaskQueue {
       buffer = buffer.next;
     }
     if (buffer.isEmpty()) {
-      if (prev !== null) {
-        prev.next = buffer.next;
+      // removing tail
+      if (prev === null) {
+        // if tail is not the last buffer
+        if (buffer.next !== null) this.tail = buffer.next;
       } else {
-        if (buffer.next) {
-          this.tail = buffer.next;
+        // removing head
+        if (buffer.next === null) {
+          this.head = prev;
+        } else {
+          // removing buffer from middle
+          prev.next = buffer.next;
         }
       }
     }

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -62,7 +62,7 @@ class FixedCircularBuffer {
   top: number
   list: Array<Task | undefined>
   next: FixedCircularBuffer | null
-  #size: number = 0
+  _size: number = 0
 
   constructor () {
     this.bottom = 0;
@@ -82,7 +82,7 @@ class FixedCircularBuffer {
   push (data:Task) {
     this.list[this.top] = data;
     this.top = (this.top + 1) & kMask;
-    this.#size++;
+    this._size++;
   }
 
   shift () {
@@ -90,7 +90,7 @@ class FixedCircularBuffer {
     if (nextItem === undefined) { return null; }
     this.list[this.bottom] = undefined;
     this.bottom = (this.bottom + 1) & kMask;
-    this.#size--;
+    this._size--;
     return nextItem;
   }
 
@@ -106,11 +106,11 @@ class FixedCircularBuffer {
       if (curr === indexToRemove) break;
       curr = next;
     }
-    this.#size--;
+    this._size--;
   }
 
   get size () {
-    return this.#size;
+    return this._size;
   }
 
   get capacity () {

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -1,0 +1,118 @@
+// Currently optimal queue size, tested on V8 6.0 - 6.6. Must be power of two.
+const kSize = 2048;
+const kMask = kSize - 1;
+
+// The FixedQueue is implemented as a singly-linked list of fixed-size
+// circular buffers. It looks something like this:
+//
+//  head                                                       tail
+//    |                                                          |
+//    v                                                          v
+// +-----------+ <-----\       +-----------+ <------\         +-----------+
+// |  [null]   |        \----- |   next    |         \------- |   next    |
+// +-----------+               +-----------+                  +-----------+
+// |   item    | <-- bottom    |   item    | <-- bottom       |  [empty]  |
+// |   item    |               |   item    |                  |  [empty]  |
+// |   item    |               |   item    |                  |  [empty]  |
+// |   item    |               |   item    |                  |  [empty]  |
+// |   item    |               |   item    |       bottom --> |   item    |
+// |   item    |               |   item    |                  |   item    |
+// |    ...    |               |    ...    |                  |    ...    |
+// |   item    |               |   item    |                  |   item    |
+// |   item    |               |   item    |                  |   item    |
+// |  [empty]  | <-- top       |   item    |                  |   item    |
+// |  [empty]  |               |   item    |                  |   item    |
+// |  [empty]  |               |  [empty]  | <-- top  top --> |  [empty]  |
+// +-----------+               +-----------+                  +-----------+
+//
+// Or, if there is only one circular buffer, it looks something
+// like either of these:
+//
+//  head   tail                                 head   tail
+//    |     |                                     |     |
+//    v     v                                     v     v
+// +-----------+                               +-----------+
+// |  [null]   |                               |  [null]   |
+// +-----------+                               +-----------+
+// |  [empty]  |                               |   item    |
+// |  [empty]  |                               |   item    |
+// |   item    | <-- bottom            top --> |  [empty]  |
+// |   item    |                               |  [empty]  |
+// |  [empty]  | <-- top            bottom --> |   item    |
+// |  [empty]  |                               |   item    |
+// +-----------+                               +-----------+
+//
+// Adding a value means moving `top` forward by one, removing means
+// moving `bottom` forward by one. After reaching the end, the queue
+// wraps around.
+//
+// When `top === bottom` the current queue is empty and when
+// `top + 1 === bottom` it's full. This wastes a single space of storage
+// but allows much quicker checks.
+
+class FixedCircularBuffer {
+  bottom: number
+  top: number
+  list: Array<unknown>
+  next: FixedCircularBuffer | null
+
+  constructor () {
+    this.bottom = 0;
+    this.top = 0;
+    this.list = new Array(kSize);
+    this.next = null;
+  }
+
+  isEmpty () {
+    return this.top === this.bottom;
+  }
+
+  isFull () {
+    return ((this.top + 1) & kMask) === this.bottom;
+  }
+
+  push (data:unknown) {
+    this.list[this.top] = data;
+    this.top = (this.top + 1) & kMask;
+  }
+
+  shift () {
+    const nextItem = this.list[this.bottom];
+    if (nextItem === undefined) { return null; }
+    this.list[this.bottom] = undefined;
+    this.bottom = (this.bottom + 1) & kMask;
+    return nextItem;
+  }
+}
+
+export default class FixedQueue {
+  head: FixedCircularBuffer
+  tail: FixedCircularBuffer
+  constructor () {
+    this.head = this.tail = new FixedCircularBuffer();
+  }
+
+  isEmpty () {
+    return this.head.isEmpty();
+  }
+
+  push (data:unknown) {
+    if (this.head.isFull()) {
+      // Head is full: Creates a new queue, sets the old queue's `.next` to it,
+      // and sets it as the new main queue.
+      this.head = this.head.next = new FixedCircularBuffer();
+    }
+    this.head.push(data);
+  }
+
+  shift () {
+    const tail = this.tail;
+    const next = tail.shift();
+    if (tail.isEmpty() && tail.next !== null) {
+      // If there is another queue, it forms the new tail.
+      this.tail = tail.next;
+      tail.next = null;
+    }
+    return next;
+  }
+};

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { TaskQueue, Task } from './common';
 // Currently optimal queue size, tested on V8 6.0 - 6.6. Must be power of two.
 const kSize = 2048;
@@ -89,7 +90,7 @@ class FixedCircularBuffer {
     // TODO: implement CircularBuffer task removal
     const indexToRemove = this.list.indexOf(task);
 
-    if (indexToRemove === -1) return;
+    assert.notStrictEqual(indexToRemove, -1);
     let curr = indexToRemove;
     while (true) {
       const next = (curr + 1) & kMask;

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -84,11 +84,39 @@ class FixedCircularBuffer {
     this.bottom = (this.bottom + 1) & kMask;
     return nextItem;
   }
+
+  remove (task: Task) {
+    // TODO: implement CircularBuffer task removal
+    const indexToRemove = this.list.indexOf(task);
+
+    if (indexToRemove === -1) return;
+    let curr = indexToRemove;
+    while (true) {
+      const next = (curr + 1) & kMask;
+      this.list[curr] = this.list[next];
+      if (this.list[curr] === undefined) break;
+      if (curr === indexToRemove) break;
+      curr = next;
+    }
+  }
+
+  get size () {
+    let count = 0;
+    for (let i = 0; i < this.list.length; i++) {
+      if (this.list[i] !== undefined) count++;
+    }
+    return count;
+  }
+
+  get capacity () {
+    return this.list.length;
+  }
 }
 
 export default class FixedQueue implements TaskQueue {
   head: FixedCircularBuffer
   tail: FixedCircularBuffer
+
   constructor () {
     this.head = this.tail = new FixedCircularBuffer();
   }
@@ -115,5 +143,28 @@ export default class FixedQueue implements TaskQueue {
       tail.next = null;
     }
     return next;
+  }
+
+  remove (task: Task) {
+    let buffer = this.head;
+    while (true) {
+      if (buffer.list.includes(task)) {
+        buffer.remove(task);
+        break;
+      }
+      if (buffer.next === null) break;
+      buffer = buffer.next;
+    }
+  }
+
+  get size () {
+    let total = 0;
+    let buffer = this.head;
+    while (true) {
+      total += buffer.size;
+      if (buffer.next === null) break;
+      buffer = buffer.next;
+    }
+    return total;
   }
 };

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -1,3 +1,8 @@
+/*
+ * Modified Fixed Queue Implementation based on the one from Node.js Project
+ * License: MIT License
+ * Source: https://github.com/nodejs/node/blob/de7b37880f5a541d5f874c1c2362a65a4be76cd0/lib/internal/fixed_queue.js
+ */
 import assert from 'node:assert';
 import { TaskQueue, Task } from './common';
 // Currently optimal queue size, tested on V8 6.0 - 6.6. Must be power of two.

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -57,6 +57,7 @@ class FixedCircularBuffer {
   top: number
   list: Array<Task | undefined>
   next: FixedCircularBuffer | null
+  #size: number = 0
 
   constructor () {
     this.bottom = 0;
@@ -76,6 +77,7 @@ class FixedCircularBuffer {
   push (data:Task) {
     this.list[this.top] = data;
     this.top = (this.top + 1) & kMask;
+    this.#size++;
   }
 
   shift () {
@@ -83,11 +85,11 @@ class FixedCircularBuffer {
     if (nextItem === undefined) { return null; }
     this.list[this.bottom] = undefined;
     this.bottom = (this.bottom + 1) & kMask;
+    this.#size--;
     return nextItem;
   }
 
   remove (task: Task) {
-    // TODO: implement CircularBuffer task removal
     const indexToRemove = this.list.indexOf(task);
 
     assert.notStrictEqual(indexToRemove, -1);
@@ -99,14 +101,11 @@ class FixedCircularBuffer {
       if (curr === indexToRemove) break;
       curr = next;
     }
+    this.#size--;
   }
 
   get size () {
-    let count = 0;
-    for (let i = 0; i < this.list.length; i++) {
-      if (this.list[i] !== undefined) count++;
-    }
-    return count;
+    return this.#size;
   }
 
   get capacity () {

--- a/src/fixed-queue.ts
+++ b/src/fixed-queue.ts
@@ -115,10 +115,6 @@ class FixedCircularBuffer {
     this.top = (this.top - 1) & kMask;
     this._size--;
   }
-
-  get capacity () {
-    return this.list.length;
-  }
 }
 
 export default class FixedQueue implements TaskQueue {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   kTransferable,
   kValue
 } from './common';
+import FixedQueue from './fixed-queue';
 import { version } from '../package.json';
 import { setTimeout as sleep } from 'timers/promises';
 
@@ -1361,11 +1362,17 @@ export default class Piscina extends EventEmitterAsyncResource {
 export const move = Piscina.move;
 export const isWorkerThread = Piscina.isWorkerThread;
 export const workerData = Piscina.workerData;
+// Mutate Piscina class to allow named import in commonjs
+// @ts-expect-error
+Piscina.FixedQueue = FixedQueue;
+// @ts-expect-error
+Piscina.ArrayTaskQueue = ArrayTaskQueue;
 
 export {
   Piscina,
   kTransferable as transferableSymbol,
   kValue as valueSymbol,
   kQueueOptions as queueOptionsSymbol,
-  version
+  version,
+  FixedQueue
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ type EnvSpecifier = typeof Worker extends {
   new (filename : never, options?: { env: infer T }) : Worker;
 } ? T : never;
 
-class ArrayTaskQueue implements TaskQueue {
+export class ArrayTaskQueue implements TaskQueue {
   tasks : Task[] = [];
 
   get size () { return this.tasks.length; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ type EnvSpecifier = typeof Worker extends {
   new (filename : never, options?: { env: infer T }) : Worker;
 } ? T : never;
 
-class ArrayTaskQueue implements TaskQueue {
+export class ArrayTaskQueue implements TaskQueue {
   tasks : Task[] = [];
 
   get size () { return this.tasks.length; }

--- a/test/fixed-queue.ts
+++ b/test/fixed-queue.ts
@@ -1,6 +1,6 @@
 import { test } from 'tap';
 import { Task, kQueueOptions } from '../dist/src/common';
-import FixedQueue from '../dist/src/fixed-queue';
+import { FixedQueue } from '..';
 
 class QueueTask implements Task {
   get [kQueueOptions] () {
@@ -36,4 +36,30 @@ test('queue remove', async ({ equal }) => {
   queue.remove(task);
 
   equal(queue.size, 0, 'should be empty after task removal');
+});
+
+test('removing elements from intermediate CircularBuffer should not lead to issues', async ({ equal, same }) => {
+  const queue = new FixedQueue();
+
+  const firstBatch = Array.from({ length: 2048 }, () => new QueueTask());
+  const secondBatch = Array.from({ length: 2048 }, () => new QueueTask());
+  const thirdBatch = Array.from({ length: 2048 }, () => new QueueTask());
+
+  const tasks = firstBatch.concat(secondBatch, thirdBatch);
+
+  for (const task of tasks) {
+    queue.push(task);
+  }
+  equal(queue.size, tasks.length, 'should contain 2048 * 3 items');
+
+  for (const task of secondBatch) {
+    queue.remove(task);
+  }
+
+  const expected = firstBatch.concat(thirdBatch);
+  const actual = [];
+  while (!queue.isEmpty()) {
+    actual.push(queue.shift());
+  }
+  same(actual, expected);
 });

--- a/test/fixed-queue.ts
+++ b/test/fixed-queue.ts
@@ -1,0 +1,39 @@
+import { test } from 'tap';
+import { Task, kQueueOptions } from '../dist/src/common';
+import FixedQueue from '../dist/src/fixed-queue';
+
+class QueueTask implements Task {
+  get [kQueueOptions] () {
+    return null;
+  }
+}
+
+test('queue length', async ({ equal }) => {
+  const queue = new FixedQueue();
+
+  equal(queue.size, 0);
+
+  queue.push(new QueueTask());
+
+  equal(queue.size, 1);
+
+  queue.shift();
+
+  equal(queue.size, 0);
+});
+
+test('queue remove', async ({ equal }) => {
+  const queue = new FixedQueue();
+
+  const task = new QueueTask();
+
+  equal(queue.size, 0, 'should be empty on start');
+
+  queue.push(task);
+
+  equal(queue.size, 1, 'should contain single task after push');
+
+  queue.remove(task);
+
+  equal(queue.size, 0, 'should be empty after task removal');
+});


### PR DESCRIPTION
Some time ago @ronag mentioned in https://github.com/piscinajs/piscina/issues/452 that Piscina could adopt Nodejs fixed_queue as TaskQueue.

This draft will fix #452.

Synthetic benchmark shows drastical speed difference when comparing fixed_queue vs queue based on plain js array.
But actual [simple-benchmark.js](https://github.com/piscinajs/piscina/blob/current/benchmark/simple-benchmark.js) shows the oposite result.
I passed FixedQueue as custom queue [here](https://github.com/JaoodxD/piscina/blob/use-fixed-queue/benchmark/simple-benchmark-2.js).
Inital `simple-benchmark.js` shows around ~82k ops on my machine, but `simple-benchmark-2.js` with `FixedQueue` shows half of original performance with ~44k ops. 

Do I miss something?
