### PR TITLE
feat: use os.availableConcurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,7 @@ This class extends [`EventEmitter`][] from Node.js.
     function. The default is `'default'`, indicating the default export of the
     worker module.
   * `minThreads`: (`number`) Sets the minimum number of threads that are always
-    running for this thread pool. The default is based on the number of
-    available CPUs.
+    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism).
   * `maxThreads`: (`number`) Sets the maximum number of threads that are
     running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5.
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long

--- a/README.md
+++ b/README.md
@@ -291,8 +291,7 @@ This class extends [`EventEmitter`][] from Node.js.
     running for this thread pool. The default is based on the number of
     available CPUs.
   * `maxThreads`: (`number`) Sets the maximum number of threads that are
-    running for this thread pool. The default is based on the number of
-    available CPUs.
+    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5.
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
     shut down. By default, this is immediate. **Tip**: *The default `idleTimeout`

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,14 +30,7 @@ import {
 import { version } from '../package.json';
 import { setTimeout as sleep } from 'timers/promises';
 
-const cpuCount : number = (() => {
-  try {
-    return cpus().length;
-  } catch {
-    /* istanbul ignore next */
-    return 1;
-  }
-})();
+const cpuParallelism : number = availableParallelism();
 
 /* eslint-disable camelcase */
 interface HistogramSummary {
@@ -199,8 +192,8 @@ interface FilledOptions extends Options {
 const kDefaultOptions : FilledOptions = {
   filename: null,
   name: 'default',
-  minThreads: Math.max(Math.floor(cpuCount / 2), 1),
-  maxThreads: cpuCount * 1.5,
+  minThreads: Math.max(Math.floor(cpuParallelism / 2), 1),
+  maxThreads: cpuParallelism * 1.5,
   idleTimeout: 0,
   maxQueue: Infinity,
   concurrentTasksPerWorker: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Worker, MessageChannel, MessagePort, receiveMessageOnPort } from 'worker_threads';
 import { once, EventEmitterAsyncResource } from 'events';
 import { AsyncResource } from 'async_hooks';
-import { cpus } from 'os';
+import { availableParallelism } from 'os';
 import { fileURLToPath, URL } from 'url';
 import { resolve } from 'path';
 import { inspect, types } from 'util';


### PR DESCRIPTION
- **feat: use available parallelism instead of cpu count**
- **fix: smaller adjustments**
