### PR TITLE
feat: allow generic when creating Piscina

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1075,7 +1075,7 @@ class ThreadPool {
   }
 }
 
-export default class Piscina extends EventEmitterAsyncResource {
+export default class Piscina<T = any, R = any> extends EventEmitterAsyncResource {
   #pool : ThreadPool;
 
   constructor (options : Options = {}) {
@@ -1142,19 +1142,19 @@ export default class Piscina extends EventEmitterAsyncResource {
   }
 
   /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : TransferList, filename? : string, abortSignal? : AbortSignalAny) : Promise<any>;
+  runTask (task : T, transferList? : TransferList, filename? : string, abortSignal? : AbortSignalAny) : Promise<R>;
 
   /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : TransferList, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
+  runTask (task : T, transferList? : TransferList, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<R>;
 
   /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : string, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<any>;
+  runTask (task : T, transferList? : string, filename? : AbortSignalAny, abortSignal? : undefined) : Promise<R>;
 
   /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : AbortSignalAny, filename? : undefined, abortSignal? : undefined) : Promise<any>;
+  runTask (task : T, transferList? : AbortSignalAny, filename? : undefined, abortSignal? : undefined) : Promise<R>;
 
   /** @deprecated Use run(task, options) instead **/
-  runTask (task : any, transferList? : any, filename? : any, signal? : any) {
+  runTask (task : T, transferList? : any, filename? : any, signal? : any): Promise<R> {
     // If transferList is a string or AbortSignal, shift it.
     if ((typeof transferList === 'object' && !Array.isArray(transferList)) ||
         typeof transferList === 'string') {
@@ -1189,7 +1189,7 @@ export default class Piscina extends EventEmitterAsyncResource {
       });
   }
 
-  run (task : any, options : RunOptions = kDefaultRunOptions) {
+  run (task : T, options : RunOptions = kDefaultRunOptions): Promise<R> {
     if (options === null || typeof options !== 'object') {
       return Promise.reject(
         new TypeError('options must be an object'));

--- a/test/generics.ts
+++ b/test/generics.ts
@@ -1,0 +1,42 @@
+import { resolve } from 'path';
+import Piscina from '..';
+import { test } from 'tap';
+
+test('Piscina<T , R> works', async ({ equal }) => {
+  const worker = new Piscina<string, number>({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  const result: number = await worker.run('Promise.resolve(42)');
+  equal(result, 42);
+});
+
+test('Piscina with no generic works', async ({ equal }) => {
+  const worker = new Piscina({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  const result = await worker.run('Promise.resolve("Hello, world!")');
+  equal(result, 'Hello, world!');
+});
+
+test('Piscina<T, R> typescript complains when invalid Task is supplied as wrong type', async ({ equal }) => {
+  const worker = new Piscina<string, number>({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  // @ts-expect-error complains due to invalid Task being number when expecting string
+  const result = await worker.run(42);
+
+  equal(result, 42);
+});
+
+test('Piscina<T, R> typescript complains when assigning Result to wrong type', async ({ equal }) => {
+  const worker = new Piscina<string, number>({
+    filename: resolve(__dirname, 'fixtures/eval.js')
+  });
+
+  // @ts-expect-error complains due to expecting a number but being assigned to a string
+  const result: string = await worker.run('Promise.resolve(42)');
+  equal(result, 42);
+});


### PR DESCRIPTION
Add ability to pass `Task` and `Return` type when creating `Piscina` class.

Example usage:

```typescript
const pool = new Piscina<MyTask, MyResult>();

// result resolves as `MyResult` and the args is expected to be a `MyTask`
const result = await pool.run({ my: 'task' }); 
```

Resolves #231.