### PR TITLE
fix: fallback to os.cpus if os.availableParallelism isn't available

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ This class extends [`EventEmitter`][] from Node.js.
     function. The default is `'default'`, indicating the default export of the
     worker module.
   * `minThreads`: (`number`) Sets the minimum number of threads that are always
-    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism).
+    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) if it's available. Otherwise, use [os.cpus](https://nodejs.org/api/os.html#oscpus).
   * `maxThreads`: (`number`) Sets the maximum number of threads that are
-    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5.
+    running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5 if it's available. Otherwise, use [os.cpus](https://nodejs.org/api/os.html#oscpus).
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
     shut down. By default, this is immediate. **Tip**: *The default `idleTimeout`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Worker, MessageChannel, MessagePort, receiveMessageOnPort } from 'node:worker_threads';
 import { once, EventEmitterAsyncResource } from 'node:events';
 import { AsyncResource } from 'node:async_hooks';
-import { availableParallelism } from 'node:os';
+import { availableParallelism, cpus } from 'node:os';
 import { resolve } from 'node:path';
 import { inspect, types } from 'node:util';
 import { RecordableHistogram, createHistogram, performance } from 'node:perf_hooks';
@@ -61,7 +61,7 @@ const { version } = JSON.parse(
     }
   ));
 
-const cpuParallelism : number = availableParallelism();
+const cpuParallelism: number =  availableParallelism ? availableParallelism() : cpus().length
 
 interface Options {
   filename? : string | null,


### PR DESCRIPTION
os.availableConcurrency added in: v19.4.0, v18.14.0. If we wanna support node16.x, we need to fallback to os.cpus if os.availableParallelism isn't available. More detail check this [PR](https://github.com/piscinajs/piscina/pull/556)