### PR TITLE
fix: close pool with minThreads=0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -620,6 +620,12 @@ class ThreadPool {
 
     const onPoolFlushed = () => new Promise<void>((resolve) => {
       const numberOfWorkers = this.workers.size;
+
+      if (numberOfWorkers === 0) {
+        resolve();
+        return;
+      }
+
       let numberOfWorkersDone = 0;
 
       const checkIfWorkerIsDone = (workerInfo: WorkerInfo) => {

--- a/test/pool-close.ts
+++ b/test/pool-close.ts
@@ -10,6 +10,12 @@ test('close()', async (t) => {
     t.pass('pool closed successfully');
   });
 
+  t.test('no pending tasks (with minThreads=0)', async (t) => {
+    const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), minThreads: 0 });
+    await pool.close();
+    t.pass('pool closed successfully');
+  });
+
   t.test('queued tasks waits for all tasks to complete', async (t) => {
     const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), maxThreads: 1 });
 


### PR DESCRIPTION
When `minThreads=0`, the worker pool can be completely empty, thus failing with a timeout when trying to close as resolve is never called.