### PR TITLE
fix: ensure errors during `getHandler` initialization are propagated

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -54,7 +54,12 @@ async function getHandler (filename : string, name : string) : Promise<Function 
     if (typeof handler !== 'function') {
       handler = await ((handler as any)[name]);
     }
-  } catch {}
+  } catch (error) {
+    if ((error as Error & {code? : string}).code !== 'MODULE_NOT_FOUND') {
+      throw error;
+    }
+  }
+
   if (typeof handler !== 'function') {
     handler = await getImportESM()(pathToFileURL(filename).href);
     if (typeof handler !== 'function') {


### PR DESCRIPTION
Previously, errors encountered during `getHandler` initialization were caught but not propagated, effectively silencing them. This update ensures that such errors are properly bubbled up for handling.