### PR TITLE
refactor(fixed_queue): use real private fields and fix TypeScript ES2022 perf regression

### DIFF
--- a/src/task_queue/fixed_queue.ts
+++ b/src/task_queue/fixed_queue.ts
@@ -116,7 +116,7 @@ class FixedCircularBuffer {
 export class FixedQueue implements TaskQueue {
   head: FixedCircularBuffer
   tail: FixedCircularBuffer
-  _size: number = 0
+  #size: number = 0
 
   constructor () {
     this.head = this.tail = new FixedCircularBuffer();
@@ -133,13 +133,13 @@ export class FixedQueue implements TaskQueue {
       this.head = this.head.next = new FixedCircularBuffer();
     }
     this.head.push(data);
-    this._size++;
+    this.#size++;
   }
 
   shift (): Task | null {
     const tail = this.tail;
     const next = tail.shift();
-    if (next !== null) this._size--;
+    if (next !== null) this.#size--;
     if (tail.isEmpty() && tail.next !== null) {
       // If there is another queue, it forms the new tail.
       this.tail = tail.next;
@@ -154,7 +154,7 @@ export class FixedQueue implements TaskQueue {
     while (true) {
       if (buffer.list.includes(task)) {
         buffer.remove(task);
-        this._size--;
+        this.#size--;
         break;
       }
       if (buffer.next === null) break;
@@ -179,6 +179,6 @@ export class FixedQueue implements TaskQueue {
   }
 
   get size () {
-    return this._size;
+    return this.#size;
   }
 };

--- a/src/task_queue/fixed_queue.ts
+++ b/src/task_queue/fixed_queue.ts
@@ -59,16 +59,12 @@ const kMask = kSize - 1;
 // but allows much quicker checks.
 
 class FixedCircularBuffer {
-  bottom: number
-  top: number
-  list: Array<Task | undefined>
-  next: FixedCircularBuffer | null
+  bottom: number = 0
+  top: number = 0
+  list: Array<Task | undefined> = new Array(kSize)
+  next: FixedCircularBuffer | null = null
 
   constructor () {
-    this.bottom = 0;
-    this.top = 0;
-    this.list = new Array(kSize);
-    this.next = null;
   }
 
   isEmpty () {

--- a/src/task_queue/fixed_queue.ts
+++ b/src/task_queue/fixed_queue.ts
@@ -64,9 +64,6 @@ class FixedCircularBuffer {
   list: Array<Task | undefined> = new Array(kSize)
   next: FixedCircularBuffer | null = null
 
-  constructor () {
-  }
-
   isEmpty () {
     return this.top === this.bottom;
   }


### PR DESCRIPTION
This pull request improves `fixed_queue` by replacing conventional underscore-prefixed properties with real JavaScript private fields. Additionally, it fixes a performance regression caused by TypeScript targeting ES2022 and newer.

The idea to migrate FixedQueue to private fields was first discussed in #555.
During implementation, a significant performance regression was discovered https://github.com/piscinajs/piscina/pull/555#issuecomment-2095523373.

### Root Causes of Regression:
1. Current project's ES target compiles private fields into drastically slower code.
2. ES2022 introduced additional in-class properties declaration which in our case lead to 15-20% perf regression.

### Solution:
- Update TypeScript target to ES2022+ to optimize private field compilation.
- Move unconditional property declarations inside the class body to eliminate unnecessary reinitialization overhead.

**Important:** *This PR does NOT update the TypeScript target to ES2022+. Until that change is made, the performance improvements shown below will not be fully realized, and older targets will still experience a significant performance regression.*  

### Benchmark Results:
Before (Main Branch, Pre-Fix)
```
> piscina@5.0.0-alpha.1 benchmark:queue:comparison
> node benchmark/queue-comparison.js

┌─────────┬─────────────────────────────────────┬──────────────────────┬──────────────────────┬────────────────────────────┬───────────────────────────┬─────────┐
│ (index) │ Task name                           │ Latency average (ns) │ Latency median (ns)  │ Throughput average (ops/s) │ Throughput median (ops/s) │ Samples │
├─────────┼─────────────────────────────────────┼──────────────────────┼──────────────────────┼────────────────────────────┼───────────────────────────┼─────────┤
│ 0       │ 'FixedQueue full push + full shift' │ '751464.93 ± 2.26%'  │ '724100.00 ± 200.00' │ '1346 ± 1.53%'             │ '1381'                    │ 134     │
└─────────┴─────────────────────────────────────┴──────────────────────┴──────────────────────┴────────────────────────────┴───────────────────────────┴─────────┘
```

After (Private Fields + ES2022 Target + Fixes)

```
> piscina@5.0.0-alpha.1 benchmark:queue:comparison
> node benchmark/queue-comparison.js

┌─────────┬─────────────────────────────────────┬──────────────────────┬─────────────────────┬────────────────────────────┬───────────────────────────┬─────────┐
│ (index) │ Task name                           │ Latency average (ns) │ Latency median (ns) │ Throughput average (ops/s) │ Throughput median (ops/s) │ Samples │
├─────────┼─────────────────────────────────────┼──────────────────────┼─────────────────────┼────────────────────────────┼───────────────────────────┼─────────┤
│ 0       │ 'FixedQueue full push + full shift' │ '744838.52 ± 1.97%'  │ '724100.00'         │ '1355 ± 1.36%'             │ '1381'                    │ 135     │
└─────────┴─────────────────────────────────────┴──────────────────────┴─────────────────────┴────────────────────────────┴───────────────────────────┴─────────┘
```

As we can see, the penalty previously investigated here https://github.com/piscinajs/piscina/pull/555#issuecomment-2095523373 has been completely eliminated.