### PR TITLE
feat: Allow long-running threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,9 @@ This class extends [`EventEmitter`][] from Node.js.
     running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5.
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
-    shut down. By default, this is immediate. If `Infinity` is passed as the value,
-    the `Worker` never shuts down. **Tip**: *The default `idleTimeout`
+    shut down. By default, this is immediate. If `Infinity` is passed as the value, 
+    the `Worker` never shuts down. Be careful when using `Infinity`, 
+    as it can lead to resource overuse. **Tip**: *The default `idleTimeout`
     can lead to some performance loss in the application because of the overhead
     involved with stopping and starting new worker threads. To improve performance,
     try setting the `idleTimeout` explicitly.*

--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ This class extends [`EventEmitter`][] from Node.js.
     running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) * 1.5.
   * `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
-    shut down. By default, this is immediate. **Tip**: *The default `idleTimeout`
+    shut down. By default, this is immediate. If `Infinity` is passed as the value,
+    the `Worker` never shuts down. **Tip**: *The default `idleTimeout`
     can lead to some performance loss in the application because of the overhead
     involved with stopping and starting new worker threads. To improve performance,
     try setting the `idleTimeout` explicitly.*

--- a/docs/docs/api-reference/class.md
+++ b/docs/docs/api-reference/class.md
@@ -37,6 +37,9 @@ This class extends [`EventEmitter`](https://nodejs.org/api/events.html) from Nod
     :::info
     The default `idleTimeout` can lead to some performance loss in the application because of the overhead involved with stopping and starting new worker threads. To improve performance, try setting the `idleTimeout` explicitly.
     :::
+    :::info
+    Be careful when when setting `idleTimeout` to `Infinity`, as this will prevent the worker from shutting down, even when idle, potentially leading to resource overuse.
+    :::
   - `maxQueue`: (`number` | `string`) The maximum number of tasks that may be
     scheduled to run, but not yet running due to lack of available threads, at
     a given time. By default, there is no limit. The special value `'auto'`

--- a/docs/docs/api-reference/class.md
+++ b/docs/docs/api-reference/class.md
@@ -32,7 +32,8 @@ This class extends [`EventEmitter`](https://nodejs.org/api/events.html) from Nod
     running for this thread pool. The default is the number provided by [`os.availableParallelism`](https://nodejs.org/api/os.html#osavailableparallelism) \* 1.5.
   - `idleTimeout`: (`number`) A timeout in milliseconds that specifies how long
     a `Worker` is allowed to be idle, i.e. not handling any tasks, before it is
-    shut down. By default, this is immediate.
+    shut down. By default, this is immediate. If `Infinity` is passed as the value,
+    the `Worker` never shuts down.
     :::info
     The default `idleTimeout` can lead to some performance loss in the application because of the overhead involved with stopping and starting new worker threads. To improve performance, try setting the `idleTimeout` explicitly.
     :::

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,6 +435,11 @@ class ThreadPool {
       }
     }
 
+    //If Infinity was sent as a parameter, we skip setting the Timeout that clears the worker
+    if (this.options.idleTimeout === Infinity) {
+      return;
+    }
+
     // If more workers than minThreads, we can remove idle workers
     if (workerInfo.currentUsage() === 0 &&
         this.workers.size > this.options.minThreads) {

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -75,4 +75,7 @@ test('idle timeout will not let go of threads if Infinity is used as the value',
 
   const lateThreadIds = await Promise.all(secondTasks);
   deepEqual(earlyThreadIds, lateThreadIds);
+
+  await Promise.all([pool.run([buffer, 6]), pool.run([buffer, 6]), pool.run([buffer, 6])]);
+  equal(pool.threads.length, 2);
 });

--- a/test/idle-timeout.ts
+++ b/test/idle-timeout.ts
@@ -42,3 +42,37 @@ test('idle timeout will let go of threads early', async ({ equal }) => {
   equal(lateThreadIds.length, 2);
   equal(new Set([...earlyThreadIds, ...lateThreadIds]).size, 3);
 });
+
+test('idle timeout will not let go of threads if Infinity is used as the value', async ({ deepEqual, equal }) => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/wait-for-others.ts'),
+    idleTimeout: Infinity,
+    minThreads: 1,
+    maxThreads: 2
+  });
+  equal(pool.threads.length, 1);
+  const buffer = new Int32Array(new SharedArrayBuffer(4));
+
+  const firstTasks = [
+    pool.run([buffer, 2]),
+    pool.run([buffer, 2])
+  ];
+  equal(pool.threads.length, 2);
+
+  const earlyThreadIds = await Promise.all(firstTasks);
+  equal(pool.threads.length, 2);
+
+  await delay(2000);
+  equal(pool.threads.length, 2);
+
+  const secondTasks = [
+    pool.run([buffer, 4]),
+    pool.run([buffer, 4]),
+  ];
+  equal(pool.threads.length, 2);
+
+
+
+  const lateThreadIds = await Promise.all(secondTasks);
+  deepEqual(earlyThreadIds, lateThreadIds);
+});


### PR DESCRIPTION
This PR aims to allow long running threads in Piscina, by leveraging the `Infinity `value on the `idleTimeout` option (See issue #678)

Using this value avoids the `setTimeout` which removes the worker when the thread is idle from being created.