### PR TITLE
chore: set minimum node version to 20.x in package `engines` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "require": "./dist/main.js"
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=20.x"
   },
   "scripts": {
     "build": "tsc && gen-esm-wrapper . dist/esm-wrapper.mjs",


### PR DESCRIPTION
Followup to PR #782