### PR TITLE
Add documentation for experimental typescript support in node

### DIFF
--- a/docs/docs/getting-started/typescript.mdx
+++ b/docs/docs/getting-started/typescript.mdx
@@ -84,6 +84,8 @@ You can also check out this example on [github](https://github.com/piscinajs/pis
 
 Starting with Node.js 23.6.0+, you can run TypeScript files directly using Node.js's [experimental TypeScript support](https://nodejs.org/api/typescript.html). This eliminates the need for external TypeScript compilers or build steps.
 
+For Node.js versions 22.6.0 to 23.5.0, you need to explicitly enable the `--experimental-strip-types` flag. However, starting from Node.js 23.6.0+, type stripping is enabled by default.
+
 ```typescript title='worker.ts'
 
 interface Inputs {
@@ -110,4 +112,3 @@ const piscina = new Piscina({
 })();
 ```
 
-For Node.js versions 22.6.0 to 23.5.0, you need to explicitly enable the `--experimental-strip-types` flag. However, starting from Node.js 23.6.0+, type stripping is enabled by default.

--- a/docs/docs/getting-started/typescript.mdx
+++ b/docs/docs/getting-started/typescript.mdx
@@ -109,3 +109,5 @@ const piscina = new Piscina({
   console.log('Result:', result);
 })();
 ```
+
+For Node.js versions 22.6.0 to 23.5.0, you need to explicitly enable the `--experimental-strip-types` flag. However, starting from Node.js 23.6.0+, type stripping is enabled by default.

--- a/docs/docs/getting-started/typescript.mdx
+++ b/docs/docs/getting-started/typescript.mdx
@@ -79,3 +79,33 @@ if (isMainThread) {
 }
 ```
 You can also check out this example on [github](https://github.com/piscinajs/piscina/tree/current/examples/typescript).
+
+## Method 3: Node.js Native TypeScript Support
+
+Starting with Node.js 23.6.0+, you can run TypeScript files directly using Node.js's [experimental TypeScript support](https://nodejs.org/api/typescript.html). This eliminates the need for external TypeScript compilers or build steps.
+
+```typescript title='worker.ts'
+
+interface Inputs {
+  a: number;
+  b: number;
+}
+
+export function addNumbers({ a, b }: Inputs): number {
+  return a + b;
+}
+```
+
+```typescript title='main.ts'
+
+import Piscina from 'piscina';
+
+const piscina = new Piscina({
+  filename: new URL("./worker.ts", import.meta.url).href,
+});
+
+(async () => {
+  const result = await piscina.run({ a: 2, b: 3 }, { name: 'addNumbers' });
+  console.log('Result:', result);
+})();
+```


### PR DESCRIPTION
Updates TypeScript documentation to cover Node.js's experimental TypeScript support.

Resolves #797 