### PR TITLE
Change assert.strictEqual to a safe early exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,7 @@ class ThreadPool {
     // If more workers than minThreads, we can remove idle workers
     if (workerInfo.currentUsage() === 0 &&
         this.workers.size > this.options.minThreads) {
-        workerInfo.idleTimeout = setTimeout(() => {        
+      workerInfo.idleTimeout = setTimeout(() => {        
         if (workerInfo.currentUsage() !== 0) {
           // Exit early - we can't safely remove the worker.
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { resolve } from 'node:path';
 import { inspect, types } from 'node:util';
 import { performance } from 'node:perf_hooks';
 import { setTimeout as sleep } from 'node:timers/promises';
-import assert from 'node:assert';
 
 import { version } from '../package.json';
 import type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,8 +443,7 @@ class ThreadPool {
     // If more workers than minThreads, we can remove idle workers
     if (workerInfo.currentUsage() === 0 &&
         this.workers.size > this.options.minThreads) {
-      workerInfo.idleTimeout = setTimeout(() => {
-        assert.strictEqual(workerInfo.currentUsage(), 0);
+      workerInfo.idleTimeout = setTimeout(() => {        
         if (this.workers.size > this.options.minThreads) {
           this._removeWorker(workerInfo);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,7 @@ class ThreadPool {
     // If more workers than minThreads, we can remove idle workers
     if (workerInfo.currentUsage() === 0 &&
         this.workers.size > this.options.minThreads) {
-      workerInfo.idleTimeout = setTimeout(() => {        
+      workerInfo.idleTimeout = setTimeout(() => {
         if (workerInfo.currentUsage() !== 0) {
           // Exit early - we can't safely remove the worker.
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,11 @@ class ThreadPool {
     // If more workers than minThreads, we can remove idle workers
     if (workerInfo.currentUsage() === 0 &&
         this.workers.size > this.options.minThreads) {
-      workerInfo.idleTimeout = setTimeout(() => {        
+        workerInfo.idleTimeout = setTimeout(() => {        
+        if (workerInfo.currentUsage() !== 0) {
+          // Exit early - we can't safely remove the worker.
+          return;
+        }
         if (this.workers.size > this.options.minThreads) {
           this._removeWorker(workerInfo);
         }


### PR DESCRIPTION
There is a `assert.strictEqual(workerInfo.currentUsage(), 0);` that multiple organizations report, breaks the Angular 20 CLI.

Exiting early by throwing an error is unnecessary and only causes programs relying on piscina to have non deterministic failure states.

This pull request removes the assert, instead of throwing an error, an early return is the appropriate response.