### PR TITLE
fix: prevent race condition in idle worker cleanup

### DIFF
--- a/src/worker_pool/index.ts
+++ b/src/worker_pool/index.ts
@@ -121,6 +121,7 @@ export class WorkerInfo extends AsynchronouslyCreatedResource {
       };
 
       try {
+        this.clearIdleTimeout();
         this.port.postMessage(message, taskInfo.transferList);
       } catch (err) {
         // This would mostly happen if e.g. message contains unserializable data
@@ -132,7 +133,6 @@ export class WorkerInfo extends AsynchronouslyCreatedResource {
       taskInfo.workerInfo = this;
       this.taskInfos.set(taskInfo.taskId, taskInfo);
       this.ref();
-      this.clearIdleTimeout();
 
       // Inform the worker that there are new messages posted, and wake it up
       // if it is waiting for one.


### PR DESCRIPTION
Resolves an issue where workers could be terminated while still in use due to an ordering problem between increasing worker usage and clearing the idle timeout. This caused `AssertionError: 1 !== 0` during cleanup.

Closes #816