### PR TITLE
test: simplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint": "eslint",
     "test": "node scripts/run-tests.js --pattern='test/**/*test.ts'",
     "test:ci": "npm run lint && npm run build && npm run test:coverage",
-    "test:unit": "node scripts/run-tests.js --pattern='test/unit/**/*test.ts'",
     "test:coverage": "node scripts/run-tests.js --coverage --pattern='test/**/*test.ts'",
     "prepack": "npm run build",
     "benchmark": "npm run benchmark:queue && npm run benchmark:piscina",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint",
     "test": "node scripts/run-tests.js --pattern='test/**/*test.ts'",
     "test:ci": "npm run lint && npm run build && npm run test:coverage",
+    "test:unit": "node scripts/run-tests.js --pattern='test/unit/**/*test.ts'",
     "test:coverage": "node scripts/run-tests.js --coverage --pattern='test/**/*test.ts'",
     "prepack": "npm run build",
     "benchmark": "npm run benchmark:queue && npm run benchmark:piscina",

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -46,11 +46,12 @@ const args = [
   ...testFiles
 ];
 
+
 let result;
 if (isCoverage) {
   result = spawnSync('c8', ['--reporter=lcov', 'node', ...args], { stdio: 'inherit' });
 } else {
-  result = spawnSync('c8', ['node', ...args], { stdio: 'inherit' });
+  result = spawnSync('node', [...args], { stdio: 'inherit' });
 }
 
 process.exit(result.status);

--- a/test/abort-task.test.ts
+++ b/test/abort-task.test.ts
@@ -1,43 +1,43 @@
-import { EventEmitter } from 'events';
-import Piscina from '..';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import Piscina from '..';
 import { resolve } from 'path';
 
 const TIMEOUT_MAX = 2 ** 31 - 1;
 
-test('tasks can be aborted through AbortController while running', async (t: TestContext) => {
+test('tasks can be aborted through AbortController while running', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
 
   const buf = new Int32Array(new SharedArrayBuffer(4));
   const abortController = new AbortController();
-  t.assert.rejects(pool.run(buf, { signal: abortController.signal }),
+  assert.rejects(pool.run(buf, { signal: abortController.signal }),
     /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
-  t.assert.strictEqual(Atomics.load(buf, 0), 1);
+  assert.strictEqual(Atomics.load(buf, 0), 1);
 
   abortController.abort();
 });
 
-test('tasks can be aborted through EventEmitter while running', async (t: TestContext) => {
+test('tasks can be aborted through EventEmitter while running', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
 
   const buf = new Int32Array(new SharedArrayBuffer(4));
   const ee = new EventEmitter();
-  t.assert.rejects(pool.run(buf, { signal: ee }), /The task has been aborted/);
+  assert.rejects(pool.run(buf, { signal: ee }), /The task has been aborted/);
 
   Atomics.wait(buf, 0, 0);
-  t.assert.strictEqual(Atomics.load(buf, 0), 1);
+  assert.strictEqual(Atomics.load(buf, 0), 1);
 
   ee.emit('abort');
 });
 
-test('tasks can be aborted through EventEmitter before running', async (t: TestContext) => {
+test('tasks can be aborted through EventEmitter before running', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.js'),
     maxThreads: 1
@@ -50,8 +50,8 @@ test('tasks can be aborted through EventEmitter before running', async (t: TestC
   const ee = new EventEmitter();
   const task1 = pool.run(bufs[0]);
   const abortable = pool.run(bufs[1], { signal: ee });
-  t.assert.strictEqual(pool.queueSize, 0); // Means it's running
-  t.assert.rejects(abortable, /The task has been aborted/);
+  assert.strictEqual(pool.queueSize, 0); // Means it's running
+  assert.rejects(abortable, /The task has been aborted/);
 
   ee.emit('abort');
 
@@ -61,7 +61,7 @@ test('tasks can be aborted through EventEmitter before running', async (t: TestC
   await task1;
 });
 
-test('abortable tasks will not share workers (abortable posted second)', async (t: TestContext) => {
+test('abortable tasks will not share workers (abortable posted second)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     maxThreads: 1,
@@ -74,8 +74,8 @@ test('abortable tasks will not share workers (abortable posted second)', async (
   ];
   const task1 = pool.run(bufs[0]);
   const ee = new EventEmitter();
-  t.assert.rejects(pool.run(bufs[1], { signal: ee }), /The task has been aborted/);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run(bufs[1], { signal: ee }), /The task has been aborted/);
+  assert.strictEqual(pool.queueSize, 0);
 
   ee.emit('abort');
 
@@ -86,7 +86,7 @@ test('abortable tasks will not share workers (abortable posted second)', async (
 });
 
 // TODO: move to testing balancer
-test('abortable tasks will not share workers (abortable posted first)', async (t: TestContext) => {
+test('abortable tasks will not share workers (abortable posted first)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -94,18 +94,18 @@ test('abortable tasks will not share workers (abortable posted first)', async (t
   });
 
   const ee = new EventEmitter();
-  t.assert.rejects(pool.run('while(true);', { signal: ee }), /The task has been aborted/);
+  assert.rejects(pool.run('while(true);', { signal: ee }), /The task has been aborted/);
   const task2 = pool.run('42');
-  t.assert.strictEqual(pool.queueSize, 1);
+  assert.strictEqual(pool.queueSize, 1);
 
   ee.emit('abort');
 
   // Wake up the thread handling the second task.
-  t.assert.strictEqual(await task2, 42);
+  assert.strictEqual(await task2, 42);
 });
 
 // TODO: move to testing balancer
-test('abortable tasks will not share workers (on worker available)', async (t: TestContext) => {
+test('abortable tasks will not share workers (on worker available)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/sleep.js'),
     maxThreads: 1,
@@ -123,12 +123,12 @@ test('abortable tasks will not share workers (on worker available)', async (t: T
     pool.run({ time: 100, a: 3 }, { signal: new EventEmitter() })
   ]);
 
-  t.assert.strictEqual(ret[0], 0);
-  t.assert.strictEqual(ret[1], 1);
-  t.assert.strictEqual(ret[2], 2);
+  assert.strictEqual(ret[0], 0);
+  assert.strictEqual(ret[1], 1);
+  assert.strictEqual(ret[2], 2);
 });
 
-test('abortable tasks will not share workers (destroy workers)', async (t: TestContext) => {
+test('abortable tasks will not share workers (destroy workers)', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/sleep.js'),
     maxThreads: 1,
@@ -145,12 +145,12 @@ test('abortable tasks will not share workers (destroy workers)', async (t: TestC
     pool.destroy();
   });
 
-  t.assert.rejects(pool.run({ time: TIMEOUT_MAX, a: 2 }), /Terminating worker thread/);
-  t.assert.rejects(pool.run({ time: TIMEOUT_MAX, a: 3 }, { signal: new EventEmitter() }),
+  assert.rejects(pool.run({ time: TIMEOUT_MAX, a: 2 }), /Terminating worker thread/);
+  assert.rejects(pool.run({ time: TIMEOUT_MAX, a: 3 }, { signal: new EventEmitter() }),
     /Terminating worker thread/);
 });
 
-test('aborted AbortSignal rejects task immediately', async (t: TestContext) => {
+test('aborted AbortSignal rejects task immediately', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -158,17 +158,17 @@ test('aborted AbortSignal rejects task immediately', async (t: TestContext) => {
   const controller = new AbortController();
   // Abort the controller early
   controller.abort();
-  t.assert.strictEqual(controller.signal.aborted, true);
+  assert.strictEqual(controller.signal.aborted, true);
 
   // The data won't be moved because the task will abort immediately.
   const data = new Uint8Array(new SharedArrayBuffer(4));
-  t.assert.rejects(pool.run(data, { signal: controller.signal, transferList: [data.buffer] }),
+  assert.rejects(pool.run(data, { signal: controller.signal, transferList: [data.buffer] }),
     /The task has been aborted/);
 
-  t.assert.strictEqual(data.length, 4);
+  assert.strictEqual(data.length, 4);
 });
 
-test('task with AbortSignal cleans up properly', async (t: TestContext) => {
+test('task with AbortSignal cleans up properly', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
@@ -179,7 +179,7 @@ test('task with AbortSignal cleans up properly', async (t: TestContext) => {
 
   const { getEventListeners } = EventEmitter as any;
   if (typeof getEventListeners === 'function') {
-    t.assert.strictEqual(getEventListeners(ee, 'abort').length, 0);
+    assert.strictEqual(getEventListeners(ee, 'abort').length, 0);
   }
 
   const controller = new AbortController();
@@ -187,7 +187,7 @@ test('task with AbortSignal cleans up properly', async (t: TestContext) => {
   await pool.run('1+1', { signal: controller.signal });
 });
 
-test('aborted AbortSignal rejects task immediately (with reason)', async (t: TestContext) => {
+test('aborted AbortSignal rejects task immediately (with reason)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -195,8 +195,8 @@ test('aborted AbortSignal rejects task immediately (with reason)', async (t: Tes
 
   const controller = new AbortController();
   controller.abort(customReason);
-  t.assert.strictEqual(controller.signal.aborted, true);
-  t.assert.strictEqual(controller.signal.reason, customReason);
+  assert.strictEqual(controller.signal.aborted, true);
+  assert.strictEqual(controller.signal.reason, customReason);
 
   // The data won't be moved because the task will abort immediately.
   const data = new Uint8Array(new SharedArrayBuffer(4));
@@ -204,14 +204,14 @@ test('aborted AbortSignal rejects task immediately (with reason)', async (t: Tes
   try {
     await pool.run(data, { transferList: [data.buffer], signal: controller.signal });
   } catch (error) {
-    t.assert.strictEqual(error.message, 'The task has been aborted');
-    t.assert.strictEqual(error.cause, customReason);
+    assert.strictEqual(error.message, 'The task has been aborted');
+    assert.strictEqual(error.cause, customReason);
   }
 
-  t.assert.strictEqual(data.length, 4);
+  assert.strictEqual(data.length, 4);
 });
 
-test('tasks can be aborted through AbortController while running', async (t: TestContext) => {
+test('tasks can be aborted through AbortController while running', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
@@ -224,18 +224,18 @@ test('tasks can be aborted through AbortController while running', async (t: Tes
     const promise = pool.run(buf, { signal: abortController.signal });
 
     Atomics.wait(buf, 0, 0);
-    t.assert.strictEqual(Atomics.load(buf, 0), 1);
+    assert.strictEqual(Atomics.load(buf, 0), 1);
 
     abortController.abort(reason);
 
     await promise;
   } catch (error) {
-    t.assert.strictEqual(error.message, 'The task has been aborted');
-    t.assert.strictEqual(error.cause, reason);
+    assert.strictEqual(error.message, 'The task has been aborted');
+    assert.strictEqual(error.cause, reason);
   }
 });
 
-test('aborted AbortSignal rejects task immediately (with reason)', async (t: TestContext) => {
+test('aborted AbortSignal rejects task immediately (with reason)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -243,8 +243,8 @@ test('aborted AbortSignal rejects task immediately (with reason)', async (t: Tes
 
   const controller = new AbortController();
   controller.abort(customReason);
-  t.assert.strictEqual(controller.signal.aborted, true);
-  t.assert.strictEqual(controller.signal.reason, customReason);
+  assert.strictEqual(controller.signal.aborted, true);
+  assert.strictEqual(controller.signal.reason, customReason);
 
   // The data won't be moved because the task will abort immediately.
   const data = new Uint8Array(new SharedArrayBuffer(4));
@@ -252,14 +252,14 @@ test('aborted AbortSignal rejects task immediately (with reason)', async (t: Tes
   try {
     await pool.run(data, { transferList: [data.buffer], signal: controller.signal });
   } catch (error) {
-    t.assert.strictEqual(error.message, 'The task has been aborted');
-    t.assert.strictEqual(error.cause, customReason);
+    assert.strictEqual(error.message, 'The task has been aborted');
+    assert.strictEqual(error.cause, customReason);
   }
 
-  t.assert.strictEqual(data.length, 4);
+  assert.strictEqual(data.length, 4);
 });
 
-test('tasks can be aborted through AbortController while running', async (t: TestContext) => {
+test('tasks can be aborted through AbortController while running', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep.ts')
   });
@@ -272,13 +272,13 @@ test('tasks can be aborted through AbortController while running', async (t: Tes
     const promise = pool.run(buf, { signal: abortController.signal });
 
     Atomics.wait(buf, 0, 0);
-    t.assert.strictEqual(Atomics.load(buf, 0), 1);
+    assert.strictEqual(Atomics.load(buf, 0), 1);
 
     abortController.abort(reason);
 
     await promise;
   } catch (error) {
-    t.assert.strictEqual(error.message, 'The task has been aborted');
-    t.assert.strictEqual(error.cause, reason);
+    assert.strictEqual(error.message, 'The task has been aborted');
+    assert.strictEqual(error.cause, reason);
   }
 });

--- a/test/async-context.test.ts
+++ b/test/async-context.test.ts
@@ -1,10 +1,11 @@
-import { createHook, executionAsyncId } from 'async_hooks';
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import { createHook, executionAsyncId } from 'node:async_hooks';
+import Piscina from '..';
 
-test('postTask() calls the correct async hooks', async (t: TestContext) => {
+
+test('postTask() calls the correct async hooks', async () => {
   let taskId;
   let initCalls = 0;
   let beforeCalls = 0;
@@ -37,8 +38,8 @@ test('postTask() calls the correct async hooks', async (t: TestContext) => {
   await pool.run('42');
 
   hook.disable();
-  t.assert.strictEqual(initCalls, 1);
-  t.assert.strictEqual(beforeCalls, 1);
-  t.assert.strictEqual(afterCalls, 1);
-  t.assert.strictEqual(resolveCalls, 1);
+  assert.strictEqual(initCalls, 1);
+  assert.strictEqual(beforeCalls, 1);
+  assert.strictEqual(afterCalls, 1);
+  assert.strictEqual(resolveCalls, 1);
 });

--- a/test/atomics-optimization.test.ts
+++ b/test/atomics-optimization.test.ts
@@ -1,11 +1,9 @@
-import { resolve } from 'node:path';
-
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-
+import { resolve } from 'node:path';
 import Piscina from '..';
 
-test('coverage test for Atomics optimization (sync mode)', async (t: TestContext) => {
+test('coverage test for Atomics optimization (sync mode)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/notify-then-sleep-or.js'),
     minThreads: 2,
@@ -33,7 +31,7 @@ test('coverage test for Atomics optimization (sync mode)', async (t: TestContext
   // The check above could also be !== 2 but it's hard to get things right
   // sometimes and this gives us a nice assertion. Basically, at this point
   // exactly 2 tasks should be in Atomics.wait() state.
-  t.assert.strictEqual(popcount8(v), 2);
+  assert.strictEqual(popcount8(v), 2);
   // Wake both tasks up as simultaneously as possible. The other 2 tasks should
   // then start executing.
   Atomics.store(i32array, 0, 0);
@@ -53,7 +51,7 @@ test('coverage test for Atomics optimization (sync mode)', async (t: TestContext
 
   // Wake up the remaining 2 tasks in order to make sure that the test finishes.
   // Do the same consistency check beforehand as above.
-  t.assert.strictEqual(popcount8(v), 2);
+  assert.strictEqual(popcount8(v), 2);
   Atomics.store(i32array, 0, 0);
   Atomics.notify(i32array, 0, Infinity);
 
@@ -85,7 +83,7 @@ test('avoids unbounded recursion', async () => {
   await Promise.all(tasks);
 });
 
-test('enable async mode', async (t: TestContext) => {
+test('enable async mode', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-params.js'),
     minThreads: 1,
@@ -112,12 +110,10 @@ test('enable async mode', async (t: TestContext) => {
     shared: bufs
   });
 
-  t.plan(2);
-
   const atResult1 = Atomics.wait(bufs[0], 0, 0);
   const atResult2 = Atomics.wait(bufs[1], 0, 0);
   const atResult3 = Atomics.wait(bufs[2], 0, 0);
 
-  t.assert.deepStrictEqual([atResult1, atResult2, atResult3], ['ok', 'ok', 'ok']);
-  t.assert.strictEqual(await promise, true);
+  assert.deepStrictEqual([atResult1, atResult2, atResult3], ['ok', 'ok', 'ok']);
+  assert.strictEqual(await promise, true);
 });

--- a/test/console-log.test.ts
+++ b/test/console-log.test.ts
@@ -1,11 +1,10 @@
+import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 import { spawn } from 'node:child_process';
-
-import concat from 'concat-stream';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import concat from 'concat-stream';
 
-test('console.log() calls are not blocked by Atomics.wait() (sync mode)', async (t: TestContext) => {
+test('console.log() calls are not blocked by Atomics.wait() (sync mode)', async () => {
   const proc = spawn(process.execPath, [
     ...process.execArgv, resolve(__dirname, 'fixtures/console-log.ts')
   ], {
@@ -21,6 +20,6 @@ test('console.log() calls are not blocked by Atomics.wait() (sync mode)', async 
   const dataStderr = await new Promise((resolve) => {
     proc.stderr.setEncoding('utf8').pipe(concat(resolve));
   });
-  t.assert.strictEqual(dataStdout, 'A\n');
-  t.assert.strictEqual(dataStderr, 'B\n');
+  assert.strictEqual(dataStdout, 'A\n');
+  assert.strictEqual(dataStderr, 'B\n');
 });

--- a/test/fixed-queue.test.ts
+++ b/test/fixed-queue.test.ts
@@ -1,8 +1,8 @@
+import assert from 'node:assert';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import { resolve } from 'node:path';
 import { kQueueOptions } from '../dist/symbols';
 import { Piscina, FixedQueue, PiscinaTask as Task } from '..';
-import { resolve } from 'node:path';
 
 // @ts-expect-error - it misses several properties, but it's enough for the test
 class QueueTask implements Task {
@@ -11,59 +11,59 @@ class QueueTask implements Task {
   }
 }
 
-test('queue length', async (t: TestContext) => {
+test('queue length', () => {
   const queue = new FixedQueue();
 
-  t.assert.strictEqual(queue.size, 0);
+  assert.strictEqual(queue.size, 0);
 
   queue.push(new QueueTask());
 
-  t.assert.strictEqual(queue.size, 1);
+  assert.strictEqual(queue.size, 1);
 
   queue.shift();
 
-  t.assert.strictEqual(queue.size, 0);
+  assert.strictEqual(queue.size, 0);
 });
 
-test('queue length should not become negative', async (t: TestContext) => {
+test('queue length should not become negative', () => {
   const queue = new FixedQueue();
 
-  t.assert.strictEqual(queue.size, 0);
+  assert.strictEqual(queue.size, 0);
 
   queue.shift();
 
-  t.assert.strictEqual(queue.size, 0);
+  assert.strictEqual(queue.size, 0);
 });
 
-test('queue remove', async (t: TestContext) => {
+test('queue remove', () => {
   const queue = new FixedQueue();
 
   const task = new QueueTask();
 
-  t.assert.strictEqual(queue.size, 0, 'should be empty on start');
+  assert.strictEqual(queue.size, 0, 'should be empty on start');
 
   queue.push(task);
 
-  t.assert.strictEqual(queue.size, 1, 'should contain single task after push');
+  assert.strictEqual(queue.size, 1, 'should contain single task after push');
 
   queue.remove(task);
 
-  t.assert.strictEqual(queue.size, 0, 'should be empty after task removal');
+  assert.strictEqual(queue.size, 0, 'should be empty after task removal');
 });
 
-test('remove not queued task should not lead to errors', async (t: TestContext) => {
+test('remove not queued task should not lead to errors', () => {
   const queue = new FixedQueue();
 
   const task = new QueueTask();
 
-  t.assert.strictEqual(queue.size, 0, 'should be empty on start');
+  assert.strictEqual(queue.size, 0, 'should be empty on start');
 
   queue.remove(task);
 
-  t.assert.strictEqual(queue.size, 0, 'should be empty after task removal');
+  assert.strictEqual(queue.size, 0, 'should be empty after task removal');
 });
 
-test('removing elements from intermediate CircularBuffer should not lead to issues', async (t: TestContext) => {
+test('removing elements from intermediate CircularBuffer should not lead to issues', () => {
   /*
       The test intends to check following scenario:
       1) We fill the queue with 3 full circular buffers amount of items.
@@ -87,12 +87,12 @@ test('removing elements from intermediate CircularBuffer should not lead to issu
   for (const task of tasks) {
     queue.push(task);
   }
-  t.assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
+  assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
 
   let size = queue.size;
   for (const task of secondBatch) {
     queue.remove(task);
-    t.assert.strictEqual(queue.size, --size, `should contain ${size} items`);
+    assert.strictEqual(queue.size, --size, `should contain ${size} items`);
   }
 
   const expected = firstBatch.concat(thirdBatch);
@@ -101,10 +101,10 @@ test('removing elements from intermediate CircularBuffer should not lead to issu
     const task = queue.shift();
     actual.push(task);
   }
-  t.assert.deepEqual(actual, expected);
+  assert.deepEqual(actual, expected);
 });
 
-test('removing elements from first CircularBuffer should not lead to issues', async (t: TestContext) => {
+test('removing elements from first CircularBuffer should not lead to issues', () => {
   /*
       The test intends to check following scenario:
       1) We fill the queue with 3 full circular buffers amount of items.
@@ -127,12 +127,12 @@ test('removing elements from first CircularBuffer should not lead to issues', as
   for (const task of tasks) {
     queue.push(task);
   }
-  t.assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
+  assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
 
   let size = queue.size;
   for (const task of firstBatch) {
     queue.remove(task);
-    t.assert.strictEqual(queue.size, --size, `should contain ${size} items`);
+    assert.strictEqual(queue.size, --size, `should contain ${size} items`);
   }
 
   const expected = secondBatch.concat(thirdBatch);
@@ -141,10 +141,10 @@ test('removing elements from first CircularBuffer should not lead to issues', as
     const task = queue.shift();
     actual.push(task);
   }
-  t.assert.deepEqual(actual, expected);
+  assert.deepEqual(actual, expected);
 });
 
-test('removing elements from last CircularBuffer should not lead to issues', async (t: TestContext) => {
+test('removing elements from last CircularBuffer should not lead to issues', async () => {
   /*
       The test intends to check following scenario:
       1) We fill the queue with 3 full circular buffers amount of items.
@@ -167,12 +167,12 @@ test('removing elements from last CircularBuffer should not lead to issues', asy
   for (const task of tasks) {
     queue.push(task);
   }
-  t.assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
+  assert.strictEqual(queue.size, tasks.length, `should contain ${batchSize} * 3 items`);
 
   let size = queue.size;
   for (const task of thirdBatch) {
     queue.remove(task);
-    t.assert.strictEqual(queue.size, --size, `should contain ${size} items`);
+    assert.strictEqual(queue.size, --size, `should contain ${size} items`);
   }
 
   const expected = firstBatch.concat(secondBatch);
@@ -181,10 +181,10 @@ test('removing elements from last CircularBuffer should not lead to issues', asy
     const task = queue.shift();
     actual.push(task);
   }
-  t.assert.deepEqual(actual, expected);
+  assert.deepEqual(actual, expected);
 });
 
-test('simple integraion with Piscina', async (t: TestContext) => {
+test('simple integraion with Piscina', async () => {
   const queue = new FixedQueue();
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread-named-import.ts'),
@@ -192,10 +192,10 @@ test('simple integraion with Piscina', async (t: TestContext) => {
   });
 
   const result = await pool.run(null);
-  t.assert.strictEqual(result, 'done');
+  assert.strictEqual(result, 'done');
 });
 
-test('concurrent calls with Piscina', async (t: TestContext) => {
+test('concurrent calls with Piscina', async () => {
   const queue = new FixedQueue();
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-async.js'),
@@ -207,5 +207,5 @@ test('concurrent calls with Piscina', async (t: TestContext) => {
   // eslint-disable-next-line
   const expected = tasks.map(eval);
 
-  t.assert.deepEqual(results, expected);
+  assert.deepEqual(results, expected);
 });

--- a/test/fixtures/console-log.ts
+++ b/test/fixtures/console-log.ts
@@ -1,5 +1,5 @@
+import { resolve } from 'node:path';
 import Piscina from '../..';
-import { resolve } from 'path';
 
 const pool = new Piscina({
   filename: resolve(__dirname, 'eval.js'),

--- a/test/fixtures/esm-async.mjs
+++ b/test/fixtures/esm-async.mjs
@@ -1,11 +1,12 @@
-import util from 'util';
-const sleep = util.promisify(setTimeout);
+import { promisify } from 'node:util';
+
+const sleep = promisify(setTimeout);
 
 // eslint-disable-next-line no-eval
 function handler (code) { return eval(code); }
 
 async function load () {
-  await sleep(100);
+  await sleep(5);
   return handler;
 }
 

--- a/test/fixtures/eval-async.js
+++ b/test/fixtures/eval-async.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const { promisify } = require('util');
+const { promisify } = require('node:util');
+
 const sleep = promisify(setTimeout);
 
 // eslint-disable-next-line no-eval
 function handler (code) { return eval(code); }
 
 async function load () {
-  await sleep(100);
+  await sleep(5);
   return handler;
 }
 

--- a/test/fixtures/move.ts
+++ b/test/fixtures/move.ts
@@ -1,6 +1,6 @@
+import assert from 'node:assert';
+import { types } from 'node:util';
 import Piscina from '../..';
-import assert from 'assert';
-import { types } from 'util';
 
 export default function (moved) {
   if (moved !== undefined) {

--- a/test/fixtures/send-buffer-then-get-length.js
+++ b/test/fixtures/send-buffer-then-get-length.js
@@ -9,7 +9,7 @@ module.exports = {
     try {
       return Piscina.move(data);
     } finally {
-      setTimeout(() => { time = data.byteLength; }, 1000);
+      setTimeout(() => { time = data.byteLength; }, 5);
     }
   },
   get: () => {

--- a/test/fixtures/send-transferrable-then-get-length.js
+++ b/test/fixtures/send-transferrable-then-get-length.js
@@ -29,7 +29,7 @@ module.exports = {
     try {
       return shared.make();
     } finally {
-      setTimeout(() => { time = data.byteLength; }, 1000);
+      setTimeout(() => { time = data.byteLength; }, 5);
     }
   },
   get: () => {

--- a/test/fixtures/simple-isworkerthread-named-import.ts
+++ b/test/fixtures/simple-isworkerthread-named-import.ts
@@ -1,5 +1,5 @@
+import assert from 'node:assert';
 import { isWorkerThread } from '../..';
-import assert from 'assert';
 
 assert.strictEqual(isWorkerThread, true);
 

--- a/test/fixtures/simple-isworkerthread.ts
+++ b/test/fixtures/simple-isworkerthread.ts
@@ -1,5 +1,5 @@
+import assert from 'node:assert';
 import Piscina from '../..';
-import assert from 'assert';
 
 assert.strictEqual(Piscina.isWorkerThread, true);
 

--- a/test/fixtures/simple-workerdata-named-import.ts
+++ b/test/fixtures/simple-workerdata-named-import.ts
@@ -1,5 +1,5 @@
+import assert from 'node:assert';
 import { workerData } from '../..';
-import assert from 'assert';
 
 assert.strictEqual(workerData, 'ABC');
 

--- a/test/fixtures/simple-workerdata.ts
+++ b/test/fixtures/simple-workerdata.ts
@@ -1,5 +1,5 @@
+import assert from 'node:assert';
 import Piscina from '../..';
-import assert from 'assert';
 
 assert.strictEqual(Piscina.workerData, 'ABC');
 

--- a/test/fixtures/sleep.js
+++ b/test/fixtures/sleep.js
@@ -1,11 +1,12 @@
 'use strict';
 
-const { promisify } = require('util');
+const { promisify } = require('node:util');
+
 const sleep = promisify(setTimeout);
 
 const buf = new Uint32Array(new SharedArrayBuffer(4));
 
-module.exports = async ({ time = 100, a }) => {
+module.exports = async ({ time = 5, a }) => {
   await sleep(time);
   const ret = Atomics.exchange(buf, 0, a);
   return ret;

--- a/test/fixtures/vm.js
+++ b/test/fixtures/vm.js
@@ -1,5 +1,5 @@
 // worker.js
-const vm = require('vm');
+const vm = require('node:vm');
 
 module.exports = ({ payload, context }) => {
   const script = new vm.Script(payload);

--- a/test/generics.test.ts
+++ b/test/generics.test.ts
@@ -1,27 +1,29 @@
-import { resolve } from 'path';
-import Piscina from '../dist';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import Piscina from '../dist';
 
-test('Piscina<T , R> works', async (t: TestContext) => {
+test('Piscina<T , R> works', async () => {
   const worker = new Piscina<string, number>({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   const result: number = await worker.run('Promise.resolve(42)');
-  t.assert.strictEqual(result, 42);
+
+  assert.strictEqual(result, 42);
 });
 
-test('Piscina with no generic works', async (t: TestContext) => {
+test('Piscina with no generic works', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   const result = await worker.run('Promise.resolve("Hello, world!")');
-  t.assert.strictEqual(result, 'Hello, world!');
+
+  assert.strictEqual(result, 'Hello, world!');
 });
 
-test('Piscina<T, R> typescript complains when invalid Task is supplied as wrong type', async (t: TestContext) => {
+test('Piscina<T, R> typescript complains when invalid Task is supplied as wrong type', async () => {
   const worker = new Piscina<string, number>({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
@@ -29,15 +31,16 @@ test('Piscina<T, R> typescript complains when invalid Task is supplied as wrong 
   // @ts-expect-error complains due to invalid Task being number when expecting string
   const result = await worker.run(42);
 
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('Piscina<T, R> typescript complains when assigning Result to wrong type', async (t: TestContext) => {
+test('Piscina<T, R> typescript complains when assigning Result to wrong type', async () => {
   const worker = new Piscina<string, number>({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   // @ts-expect-error complains due to expecting a number but being assigned to a string
   const result: string = await worker.run('Promise.resolve(42)');
-  t.assert.strictEqual(result, 42);
+
+  assert.strictEqual(result, 42);
 });

--- a/test/histogram.test.ts
+++ b/test/histogram.test.ts
@@ -1,116 +1,117 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
 import { test } from 'node:test';
 import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import Piscina from '..';
 import { PiscinaWorker } from '../dist/worker_pool';
 
-test('pool will maintain run and wait time histograms by default', async (t: TestContext) => {
+test('pool will maintain run and wait time histograms by default', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
+  for (let n = 0; n < 5; n++) {
     tasks.push(pool.run('42'));
   }
   await Promise.all(tasks);
 
   const histogram = pool.histogram;
   const waitTime = histogram.waitTime;
-  t.assert.ok(waitTime);
-  t.assert.strictEqual(typeof waitTime.average, 'number');
-  t.assert.strictEqual(typeof waitTime.mean, 'number');
-  t.assert.strictEqual(typeof waitTime.stddev, 'number');
-  t.assert.strictEqual(typeof waitTime.min, 'number');
-  t.assert.strictEqual(typeof waitTime.max, 'number');
+  assert.ok(waitTime);
+  assert.strictEqual(typeof waitTime.average, 'number');
+  assert.strictEqual(typeof waitTime.mean, 'number');
+  assert.strictEqual(typeof waitTime.stddev, 'number');
+  assert.strictEqual(typeof waitTime.min, 'number');
+  assert.strictEqual(typeof waitTime.max, 'number');
 
   const runTime = histogram.runTime;
-  t.assert.ok(runTime);
-  t.assert.strictEqual(typeof runTime.average, 'number');
-  t.assert.strictEqual(typeof runTime.mean, 'number');
-  t.assert.strictEqual(typeof runTime.stddev, 'number');
-  t.assert.strictEqual(typeof runTime.min, 'number');
-  t.assert.strictEqual(typeof runTime.max, 'number');
-  t.assert.strictEqual(typeof histogram.resetRunTime, 'function');
-  t.assert.strictEqual(typeof histogram.resetWaitTime, 'function');
+  assert.ok(runTime);
+  assert.strictEqual(typeof runTime.average, 'number');
+  assert.strictEqual(typeof runTime.mean, 'number');
+  assert.strictEqual(typeof runTime.stddev, 'number');
+  assert.strictEqual(typeof runTime.min, 'number');
+  assert.strictEqual(typeof runTime.max, 'number');
+  assert.strictEqual(typeof histogram.resetRunTime, 'function');
+  assert.strictEqual(typeof histogram.resetWaitTime, 'function');
 });
 
-test('pool will maintain reset histograms upon call', async (t: TestContext) => {
+test('pool will maintain reset histograms upon call', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
+  for (let n = 0; n < 5; n++) {
     tasks.push(pool.run('42'));
   }
   await Promise.all(tasks);
 
   const histogram = pool.histogram;
   let waitTime = histogram.waitTime;
-  t.assert.ok(waitTime);
-  t.assert.strictEqual(typeof waitTime.average, 'number');
-  t.assert.strictEqual(typeof waitTime.mean, 'number');
-  t.assert.strictEqual(typeof waitTime.stddev, 'number');
-  t.assert.ok(waitTime.min > 0);
-  t.assert.ok(waitTime.max > 0);
+  assert.ok(waitTime);
+  assert.strictEqual(typeof waitTime.average, 'number');
+  assert.strictEqual(typeof waitTime.mean, 'number');
+  assert.strictEqual(typeof waitTime.stddev, 'number');
+  assert.ok(waitTime.min > 0);
+  assert.ok(waitTime.max > 0);
 
   let runTime = histogram.runTime;
-  t.assert.ok(runTime);
-  t.assert.strictEqual(typeof runTime.average, 'number');
-  t.assert.strictEqual(typeof runTime.mean, 'number');
-  t.assert.strictEqual(typeof runTime.stddev, 'number');
-  t.assert.ok(runTime.min > 0);
-  t.assert.ok(runTime.max > 0);
+  assert.ok(runTime);
+  assert.strictEqual(typeof runTime.average, 'number');
+  assert.strictEqual(typeof runTime.mean, 'number');
+  assert.strictEqual(typeof runTime.stddev, 'number');
+  assert.ok(runTime.min > 0);
+  assert.ok(runTime.max > 0);
 
   histogram.resetRunTime();
   runTime = histogram.runTime;
-  t.assert.ok(Number.isNaN(runTime.average));
-  t.assert.ok(Number.isNaN(runTime.mean));
-  t.assert.ok(Number.isNaN(runTime.stddev));
-  t.assert.strictEqual(runTime.max, 0);
-  
+  assert.ok(Number.isNaN(runTime.average));
+  assert.ok(Number.isNaN(runTime.mean));
+  assert.ok(Number.isNaN(runTime.stddev));
+  assert.strictEqual(runTime.max, 0);
+
   histogram.resetWaitTime();
   waitTime = histogram.waitTime;
-  t.assert.ok(Number.isNaN(waitTime.average));
-  t.assert.ok(Number.isNaN(waitTime.mean));
-  t.assert.ok(Number.isNaN(waitTime.stddev));
-  t.assert.strictEqual(waitTime.max, 0);
+  assert.ok(Number.isNaN(waitTime.average));
+  assert.ok(Number.isNaN(waitTime.mean));
+  assert.ok(Number.isNaN(waitTime.stddev));
+  assert.strictEqual(waitTime.max, 0);
 });
 
-test('pool will maintain run and wait time histograms when recordTiming is true', async (t: TestContext) => {
+test('pool will maintain run and wait time histograms when recordTiming is true', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     recordTiming: true
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
+  for (let n = 0; n < 5; n++) {
     tasks.push(pool.run('42'));
   }
   await Promise.all(tasks);
 
   const waitTime = pool.histogram.waitTime;
-  t.assert.ok(waitTime);
+  assert.ok(waitTime);
 
   const runTime = pool.histogram.runTime;
-  t.assert.ok(runTime);
+  assert.ok(runTime);
 });
 
-test('pool does not maintain run and wait time histograms when recordTiming is false', async (t: TestContext) => {
+test('pool does not maintain run and wait time histograms when recordTiming is false', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     recordTiming: false
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
+  for (let n = 0; n < 5; n++) {
     tasks.push(pool.run('42'));
   }
   await Promise.all(tasks);
 
-  t.assert.ok(!pool.histogram.waitTime);
-  t.assert.ok(!pool.histogram.runTime);
+  assert.ok(!pool.histogram.waitTime);
+  assert.ok(!pool.histogram.runTime);
 });
 
 test('workers has histogram', async (t: TestContext) => {
@@ -141,7 +142,7 @@ test('workers has histogram', async (t: TestContext) => {
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
+  for (let n = 0; n < 5; n++) {
     tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
   }
   await Promise.all(tasks);
@@ -156,7 +157,7 @@ test('workers does not have histogram if disabled', async (t: TestContext) => {
   let index = 0;
   // After each task the balancer is called to distribute the next task
   // The first task is distributed, the second is enqueued, once the first is done, the second is distributed and normalizes
-  t.plan(10 * 2);
+  t.plan(5 * 2);
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -177,8 +178,8 @@ test('workers does not have histogram if disabled', async (t: TestContext) => {
   });
 
   const tasks = [];
-  for (let n = 0; n < 10; n++) {
-    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
+  for (let n = 0; n < 5; n++) {
+    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))'));
   }
   await Promise.all(tasks);
 });

--- a/test/idle-timeout.test.ts
+++ b/test/idle-timeout.test.ts
@@ -1,82 +1,82 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
-import { promisify } from 'util';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import Piscina from '..';
 
 const delay = promisify(setTimeout);
 
-test('idle timeout will let go of threads early',  async (t: TestContext) => {
+test('idle timeout will let go of threads early',  async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-others.ts'),
-    idleTimeout: 500,
+    idleTimeout: 50, // 50ms
     minThreads: 1,
     maxThreads: 2
   });
 
-  t.assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.threads.length, 1);
   const buffer = new Int32Array(new SharedArrayBuffer(4));
 
   const firstTasks = [
     pool.run([buffer, 2]),
     pool.run([buffer, 2])
   ];
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
   const earlyThreadIds = await Promise.all(firstTasks);
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
-  await delay(2000);
-  t.assert.strictEqual(pool.threads.length, 1);
+  await delay(100);
+  assert.strictEqual(pool.threads.length, 1);
 
   const secondTasks = [
     pool.run([buffer, 4]),
     pool.run([buffer, 4])
   ];
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
   const lateThreadIds = await Promise.all(secondTasks);
 
   // One thread should have been idle in between and exited, one should have
   // been reused.
-  t.assert.strictEqual(earlyThreadIds.length, 2);
-  t.assert.strictEqual(lateThreadIds.length, 2);
-  t.assert.strictEqual(new Set([...earlyThreadIds, ...lateThreadIds]).size, 3);
+  assert.strictEqual(earlyThreadIds.length, 2);
+  assert.strictEqual(lateThreadIds.length, 2);
+  assert.strictEqual(new Set([...earlyThreadIds, ...lateThreadIds]).size, 3);
 });
 
-test('idle timeout will not let go of threads if Infinity is used as the value',  async (t: TestContext) => {
+test('idle timeout will not let go of threads if Infinity is used as the value',  async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-others.ts'),
     idleTimeout: Infinity,
     minThreads: 1,
     maxThreads: 2
   });
-  t.assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.threads.length, 1);
   const buffer = new Int32Array(new SharedArrayBuffer(4));
 
   const firstTasks = [
     pool.run([buffer, 2]),
     pool.run([buffer, 2])
   ];
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
   const earlyThreadIds = await Promise.all(firstTasks);
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
-  await delay(2000);
-  t.assert.strictEqual(pool.threads.length, 2);
+  await delay(1000);
+  assert.strictEqual(pool.threads.length, 2);
 
   const secondTasks = [
     pool.run([buffer, 4]),
     pool.run([buffer, 4]),
   ];
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
 
 
   const lateThreadIds = await Promise.all(secondTasks);
-  t.assert.deepStrictEqual(earlyThreadIds, lateThreadIds);
+  assert.deepStrictEqual(earlyThreadIds, lateThreadIds);
 
   await Promise.all([pool.run([buffer, 6]), pool.run([buffer, 6]), pool.run([buffer, 6])]);
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 });

--- a/test/issue-513.test.ts
+++ b/test/issue-513.test.ts
@@ -1,17 +1,17 @@
-import Piscina from '..';
+import assert from 'node:assert';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import Piscina from '..';
 
-test('pool will maintain run and wait time histograms', async (t: TestContext) => {
+test('pool will maintain run and wait time histograms', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/vm.js')
   });
 
   try {
     await pool.run({ payload: 'throw new Error("foo")' });
-    t.assert.fail('Expected an error');
+    assert.fail('Expected an error');
   } catch (error) {
-    t.assert.strictEqual(error.message, 'foo');
+    assert.strictEqual(error.message, 'foo');
   }
 });

--- a/test/load-with-esm.test.ts
+++ b/test/load-with-esm.test.ts
@@ -1,15 +1,16 @@
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+
 
 const importESM : (specifier : string) => Promise<any> =
   // eslint-disable-next-line no-eval
   eval('(specifier) => import(specifier)');
 
-test('Piscina is default export', {}, async (t: TestContext) => {
-  t.assert.strictEqual((await importESM('piscina')).default, require('../'));
+test('Piscina is default export', {}, async () => {
+  assert.strictEqual((await importESM('piscina')).default, require('../'));
 });
 
-test('Exports match own property names', {}, async (t: TestContext) => {
+test('Exports match own property names', {}, async () => {
   // Check that version, workerData, etc. are re-exported.
   const exported = new Set(Object.getOwnPropertyNames(await importESM('piscina')));
   const required = new Set(Object.getOwnPropertyNames(require('../')));
@@ -18,5 +19,5 @@ test('Exports match own property names', {}, async (t: TestContext) => {
   for (const k of ['prototype', 'length', 'name']) required.delete(k);
   exported.delete('default');
 
-  t.assert.deepStrictEqual(exported, required);
+  assert.deepStrictEqual(exported, required);
 });

--- a/test/messages.test.ts
+++ b/test/messages.test.ts
@@ -1,10 +1,10 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
-import { once } from 'events';
+import { resolve } from 'node:path';
+import { once } from 'node:events';
+import Piscina from '..';
 
-test('Pool receive message from workers',  async (t: TestContext) => {
+test('Pool receive message from workers', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
@@ -15,6 +15,7 @@ test('Pool receive message from workers',  async (t: TestContext) => {
         require('worker_threads').parentPort.postMessage("some message");
         42
     `);
-  t.assert.strictEqual(await taskResult, 42);
-  t.assert.strictEqual((await messagePromise)[0], 'some message');
+
+  assert.strictEqual(await taskResult, 42);
+  assert.strictEqual((await messagePromise)[0], 'some message');
 });

--- a/test/move-test.test.ts
+++ b/test/move-test.test.ts
@@ -1,76 +1,76 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { types } from 'node:util';
+import { MessageChannel, MessagePort } from 'node:worker_threads';
+import { resolve } from 'node:path';
 import Piscina from '..';
 import {
   isMovable,
   markMovable,
   isTransferable
 } from '../dist/common';
-import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { types } from 'util';
-import { MessageChannel, MessagePort } from 'worker_threads';
-import { resolve } from 'path';
 
 const {
   transferableSymbol,
   valueSymbol
 } = Piscina;
 
-test('Marking an object as movable works as expected', async (t: TestContext) => {
+test('Marking an object as movable works as expected', () => {
   const obj : any = {
     get [transferableSymbol] () : object { return {}; },
     get [valueSymbol] () : object { return {}; }
   };
-  t.assert.ok(isTransferable(obj));
-  t.assert.ok(!isMovable(obj)); // It's not movable initially
+  assert.ok(isTransferable(obj));
+  assert.ok(!isMovable(obj)); // It's not movable initially
   markMovable(obj);
-  t.assert.ok(isMovable(obj)); // It is movable now
+  assert.ok(isMovable(obj)); // It is movable now
 });
 
-test('Marking primitives and null works as expected', async (t: TestContext) => {
-  t.assert.strictEqual(Piscina.move(null), null);
-  t.assert.strictEqual(Piscina.move(1 as any), 1);
-  t.assert.strictEqual(Piscina.move(false as any), false);
-  t.assert.strictEqual(Piscina.move('test' as any), 'test');
+test('Marking primitives and null works as expected', () => {
+  assert.strictEqual(Piscina.move(null), null);
+  assert.strictEqual(Piscina.move(1 as any), 1);
+  assert.strictEqual(Piscina.move(false as any), false);
+  assert.strictEqual(Piscina.move('test' as any), 'test');
 });
 
-test('Using Piscina.move() returns a movable object', async (t: TestContext) => {
+test('Using Piscina.move() returns a movable object', () => {
   const obj : any = {
     get [transferableSymbol] () : object { return {}; },
     get [valueSymbol] () : object { return {}; }
   };
-  t.assert.ok(!isMovable(obj)); // It's not movable initially
+  assert.ok(!isMovable(obj)); // It's not movable initially
   const movable = Piscina.move(obj);
-  t.assert.ok(isMovable(movable)); // It is movable now
+  assert.ok(isMovable(movable)); // It is movable now
 });
 
-test('Using ArrayBuffer works as expected', async (t: TestContext) => {
+test('Using ArrayBuffer works as expected', () => {
   const ab = new ArrayBuffer(5);
   const movable = Piscina.move(ab);
-  t.assert.ok(isMovable(movable));
-  t.assert.ok(types.isAnyArrayBuffer(movable[valueSymbol]));
-  t.assert.ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
-  t.assert.strictEqual(movable[transferableSymbol], ab);
+  assert.ok(isMovable(movable));
+  assert.ok(types.isAnyArrayBuffer(movable[valueSymbol]));
+  assert.ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
+  assert.strictEqual(movable[transferableSymbol], ab);
 });
 
-test('Using TypedArray works as expected', async (t: TestContext) => {
+test('Using TypedArray works as expected', () => {
   const ab = new Uint8Array(5);
   const movable = Piscina.move(ab);
-  t.assert.ok(isMovable(movable));
-  t.assert.ok((types as any).isArrayBufferView(movable[valueSymbol]));
-  t.assert.ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
-  t.assert.strictEqual(movable[transferableSymbol], ab.buffer);
+  assert.ok(isMovable(movable));
+  assert.ok((types as any).isArrayBufferView(movable[valueSymbol]));
+  assert.ok(types.isAnyArrayBuffer(movable[transferableSymbol]));
+  assert.strictEqual(movable[transferableSymbol], ab.buffer);
 });
 
-test('Using MessagePort works as expected', async (t: TestContext) => {
+test('Using MessagePort works as expected', () => {
   const mc = new MessageChannel();
   const movable = Piscina.move(mc.port1);
-  t.assert.ok(isMovable(movable));
-  t.assert.ok(movable[valueSymbol] instanceof MessagePort);
-  t.assert.ok(movable[transferableSymbol] instanceof MessagePort);
-  t.assert.strictEqual(movable[transferableSymbol], mc.port1);
+  assert.ok(isMovable(movable));
+  assert.ok(movable[valueSymbol] instanceof MessagePort);
+  assert.ok(movable[transferableSymbol] instanceof MessagePort);
+  assert.strictEqual(movable[transferableSymbol], mc.port1);
 });
 
-test('Moving works', async (t: TestContext) => {
+test('Moving works', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/move.ts')
   });
@@ -79,15 +79,15 @@ test('Moving works', async (t: TestContext) => {
     // Test with empty transferList
     const ab = new ArrayBuffer(10);
     const ret = await pool.run(Piscina.move(ab));
-    t.assert.strictEqual(ab.byteLength, 0); // It was moved
-    t.assert.ok(types.isAnyArrayBuffer(ret));
+    assert.strictEqual(ab.byteLength, 0); // It was moved
+    assert.ok(types.isAnyArrayBuffer(ret));
   }
 
   {
     // Test with empty transferList
     const ab = new ArrayBuffer(10);
     const ret = await pool.run(Piscina.move(ab), { transferList: [] });
-    t.assert.strictEqual(ab.byteLength, 0); // It was moved
-    t.assert.ok(types.isAnyArrayBuffer(ret));
+    assert.strictEqual(ab.byteLength, 0); // It was moved
+    assert.ok(types.isAnyArrayBuffer(ret));
   }
 });

--- a/test/nice.test.ts
+++ b/test/nice.test.ts
@@ -1,13 +1,13 @@
-import Piscina from '..';
-import { getCurrentProcessPriority, WindowsThreadPriority } from '@napi-rs/nice';
-import { resolve } from 'path';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import { getCurrentProcessPriority, WindowsThreadPriority } from '@napi-rs/nice';
+import Piscina from '..';
 
 test('niceness - Linux:', { skip: process.platform !== 'linux' }, async scope => {
   scope.plan(2);
 
-  await scope.test('can set niceness for threads on Linux', async (t: TestContext) => {
+  await scope.test('can set niceness for threads on Linux', async () => {
     const worker = new Piscina({
       filename: resolve(__dirname, 'fixtures/eval.js'),
       niceIncrement: 5
@@ -19,17 +19,17 @@ test('niceness - Linux:', { skip: process.platform !== 'linux' }, async scope =>
     const result = await worker.run('require("@napi-rs/nice").getCurrentProcessPriority()');
     // niceness is capped to 19 on Linux.
     const expected = Math.min(currentNiceness + 5, 19);
-    t.assert.strictEqual(result, expected);
+    assert.strictEqual(result, expected);
   });
 
-  await scope.test('setting niceness never does anything bad', async (t: TestContext) => {
+  await scope.test('setting niceness never does anything bad', async () => {
     const worker = new Piscina({
       filename: resolve(__dirname, 'fixtures/eval.js'),
       niceIncrement: 5
     });
 
     const result = await worker.run('42');
-    t.assert.strictEqual(result, 42);
+    assert.strictEqual(result, 42);
   });
 });
 
@@ -37,7 +37,7 @@ test('niceness - Windows', {
   skip: process.platform !== 'win32'
 }, scope => {
   scope.plan(1);
-  scope.test('can set niceness for threads on Windows', async (t: TestContext) => {
+  scope.test('can set niceness for threads on Windows', async () => {
     const worker = new Piscina({
       filename: resolve(__dirname, 'fixtures/eval.js'),
       niceIncrement: WindowsThreadPriority.ThreadPriorityAboveNormal
@@ -45,6 +45,6 @@ test('niceness - Windows', {
 
     const result = await worker.run('require("@napi-rs/nice").getCurrentProcessPriority()');
 
-    t.assert.strictEqual(result, WindowsThreadPriority.ThreadPriorityAboveNormal);
+    assert.strictEqual(result, WindowsThreadPriority.ThreadPriorityAboveNormal);
   });
 });

--- a/test/option-validation.test.ts
+++ b/test/option-validation.test.ts
@@ -1,132 +1,132 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import Piscina from '..';
 
-test('filename cannot be non-null/non-string', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('filename cannot be non-null/non-string',() => {
+  assert.throws(() => new Piscina(({
     filename: 12
   }) as any), /options.filename must be a string or null/);
 });
 
-test('name cannot be non-null/non-string', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('name cannot be non-null/non-string', () => {
+  assert.throws(() => new Piscina(({
     name: 12
   }) as any), /options.name must be a string or null/);
 });
 
-test('minThreads must be non-negative integer', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('minThreads must be non-negative integer', () => {
+  assert.throws(() => new Piscina(({
     minThreads: -1
   }) as any), /options.minThreads must be a non-negative integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     minThreads: 'string'
   }) as any), /options.minThreads must be a non-negative integer/);
 });
 
-test('maxThreads must be positive integer', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('maxThreads must be positive integer', () => {
+  assert.throws(() => new Piscina(({
     maxThreads: -1
   }) as any), /options.maxThreads must be a positive integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     maxThreads: 0
   }) as any), /options.maxThreads must be a positive integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     maxThreads: 'string'
   }) as any), /options.maxThreads must be a positive integer/);
 });
 
-test('concurrentTasksPerWorker must be positive integer', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('concurrentTasksPerWorker must be positive integer', () => {
+  assert.throws(() => new Piscina(({
     concurrentTasksPerWorker: -1
   }) as any), /options.concurrentTasksPerWorker must be a positive integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     concurrentTasksPerWorker: 0
   }) as any), /options.concurrentTasksPerWorker must be a positive integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     concurrentTasksPerWorker: 'string'
   }) as any), /options.concurrentTasksPerWorker must be a positive integer/);
 });
 
-test('idleTimeout must be non-negative integer', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('idleTimeout must be non-negative integer', () => {
+  assert.throws(() => new Piscina(({
     idleTimeout: -1
   }) as any), /options.idleTimeout must be a non-negative integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     idleTimeout: 'string'
   }) as any), /options.idleTimeout must be a non-negative integer/);
 });
 
-test('maxQueue must be non-negative integer', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('maxQueue must be non-negative integer', () => {
+  assert.throws(() => new Piscina(({
     maxQueue: -1
   }) as any), /options.maxQueue must be a non-negative integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     maxQueue: 'string'
   }) as any), /options.maxQueue must be a non-negative integer/);
 
   const p = new Piscina({ maxQueue: 'auto', maxThreads: 2 });
-  t.assert.strictEqual(p.options.maxQueue, 4);
+  assert.strictEqual(p.options.maxQueue, 4);
 });
 
-test('atomics must be valid', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('atomics must be valid', () => {
+  assert.throws(() => new Piscina(({
     atomics: -1
   }) as any), /options.atomics should be a value of sync, sync or disabled./);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     atomics: 'string'
   }) as any), /options.atomics should be a value of sync, sync or disabled./);
 });
 
-test('resourceLimits must be an object', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('resourceLimits must be an object', () => {
+  assert.throws(() => new Piscina(({
     resourceLimits: 0
   }) as any), /options.resourceLimits must be an object/);
 });
 
-test('taskQueue must be a TaskQueue object', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('taskQueue must be a TaskQueue object', () => {
+  assert.throws(() => new Piscina(({
     taskQueue: 0
   }) as any), /options.taskQueue must be a TaskQueue object/);
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     taskQueue: 'test'
   }) as any), /options.taskQueue must be a TaskQueue object/);
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     taskQueue: null
   }) as any), /options.taskQueue must be a TaskQueue object/);
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     taskQueue: new Date()
   }) as any), /options.taskQueue must be a TaskQueue object/);
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     taskQueue: { } as any
   }) as any), /options.taskQueue must be a TaskQueue object/);
 });
 
 test('niceIncrement must be non-negative integer on Unix', {
   skip: process.platform === 'win32' ? 'Unix options validate' : false
-}, async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+}, () => {
+  assert.throws(() => new Piscina(({
     niceIncrement: -1
   }) as any), /options.niceIncrement must be a non-negative integer/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     niceIncrement: 'string'
   }) as any), /options.niceIncrement must be a non-negative integer/);
 });
 
-test('trackUnmanagedFds must be a boolean', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('trackUnmanagedFds must be a boolean', () => {
+  assert.throws(() => new Piscina(({
     trackUnmanagedFds: -1
   }) as any), /options.trackUnmanagedFds must be a boolean/);
 
-  t.assert.throws(() => new Piscina(({
+  assert.throws(() => new Piscina(({
     trackUnmanagedFds: 'string'
   }) as any), /options.trackUnmanagedFds must be a boolean/);
 });

--- a/test/pool-close.test.ts
+++ b/test/pool-close.test.ts
@@ -1,88 +1,84 @@
+import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import { resolve } from 'node:path';
-
 import { describe, it, test } from 'node:test';
-import type { TestContext } from 'node:test';
-
 import Piscina from '..';
 
-describe('close()', async (t: TestContext) => {
-  it('no pending tasks', async (t: TestContext) => {
+describe('close()', () => {
+  it('no pending tasks', async () => {
     const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js') });
     await pool.close();
-    t.assert.ok('pool closed successfully');
+    assert.ok('pool closed successfully');
   });
 
-  it('no pending tasks (with minThreads=0)', async (t: TestContext) => {
+  it('no pending tasks (with minThreads=0)', async () => {
     const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), minThreads: 0 });
     await pool.close();
-    t.assert.ok('pool closed successfully');
+    assert.ok('pool closed successfully');
   });
 });
 
-test('queued tasks waits for all tasks to complete', async (t: TestContext) => {
+test('queued tasks waits for all tasks to complete', async () => {
   const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), maxThreads: 1 });
 
   const task1 = pool.run({ time: 100 });
   const task2 = pool.run({ time: 100 });
-  setImmediate(() => t.assert.doesNotReject(pool.close(), 'close is resolved when all running tasks are completed'));
+  setImmediate(() => assert.doesNotReject(pool.close(), 'close is resolved when all running tasks are completed'));
   await Promise.all([
-    t.assert.doesNotReject(once(pool, 'close'), 'handler is called when pool is closed'),
-    t.assert.doesNotReject(task1, 'complete running task'),
-    t.assert.doesNotReject(task2, 'complete running task')
+    assert.doesNotReject(once(pool, 'close'), 'handler is called when pool is closed'),
+    assert.doesNotReject(task1, 'complete running task'),
+    assert.doesNotReject(task2, 'complete running task')
   ]);
 });
 
-test('abort any task enqueued during closing up', async (t: TestContext) => {
+test('abort any task enqueued during closing up', async () => {
   const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), maxThreads: 1 });
 
   setImmediate(() => {
-    t.assert.doesNotReject(pool.close(), 'close is resolved when running tasks are completed');
-    t.assert.doesNotReject(pool.run({ time: 1000 }).then(null, err => {
-      t.assert.strictEqual(err.message, 'The task has been aborted');
-      t.assert.strictEqual(err.cause, 'queue is being terminated');
+    assert.doesNotReject(pool.close(), 'close is resolved when running tasks are completed');
+    assert.doesNotReject(pool.run({ time: 1000 }).then(null, err => {
+      assert.strictEqual(err.message, 'The task has been aborted');
+      assert.strictEqual(err.cause, 'queue is being terminated');
     }));
   });
 
-  await t.assert.doesNotReject(pool.run({ time: 100 }), 'complete running task');
+  await assert.doesNotReject(pool.run({ time: 100 }), 'complete running task');
 });
 
-test('force: queued tasks waits for all tasks already running and aborts tasks that are not started yet', async (t: TestContext) => {
+test('force: queued tasks waits for all tasks already running and aborts tasks that are not started yet', async () => {
   const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/sleep.js'), maxThreads: 1, concurrentTasksPerWorker: 2 });
 
-  const task1 = pool.run({ time: 1000 });
-  const task2 = pool.run({ time: 1000 });
+  const task1 = pool.run({ time: 5 });
+  const task2 = pool.run({ time: 5 });
   // const task3 = pool.run({ time: 100 });
   // const task4 = pool.run({ time: 100 });
 
-  t.plan(6);
-
-  t.assert.doesNotReject(pool.close({ force: true }));
-  t.assert.doesNotReject(once(pool, 'close'), 'handler is called when pool is closed');
-  t.assert.doesNotReject(task1, 'complete running task');
-  t.assert.doesNotReject(task2, 'complete running task');
-  t.assert.rejects(pool.run({ time: 100 }), /The task has been aborted/, 'abort task that are not started yet');
-  t.assert.rejects(pool.run({ time: 100 }), /The task has been aborted/, 'abort task that are not started yet');
+  assert.doesNotReject(pool.close({ force: true }));
+  assert.doesNotReject(once(pool, 'close'), 'handler is called when pool is closed');
+  assert.doesNotReject(task1, 'complete running task');
+  assert.doesNotReject(task2, 'complete running task');
+  assert.rejects(pool.run({ time: 100 }), /The task has been aborted/, 'abort task that are not started yet');
+  assert.rejects(pool.run({ time: 100 }), /The task has been aborted/, 'abort task that are not started yet');
 
   await task1;
   await task2;
 });
 
-test('timed out close operation destroys the pool', async (t: TestContext) => {
+test('timed out close operation destroys the pool', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/sleep.js'),
     maxThreads: 1,
-    closeTimeout: 500
+    closeTimeout: 5 // 5ms
   });
 
-  const task1 = pool.run({ time: 5000 });
-  const task2 = pool.run({ time: 5000 });
+  const task1 = pool.run({ time: 50 });
+  const task2 = pool.run({ time: 50 });
 
-  setImmediate(() => t.assert.doesNotReject(pool.close(), 'close is resolved on timeout'));
+  setImmediate(() => assert.doesNotReject(pool.close(), 'close is resolved on timeout'));
 
   await Promise.all([
-    t.assert.doesNotReject(once(pool, 'error'), 'error handler is called on timeout'),
-    t.assert.rejects(task1, /Terminating worker thread/, 'task is aborted due to timeout'),
-    t.assert.rejects(task2, /Terminating worker thread/, 'task is aborted due to timeout')
+    assert.doesNotReject(once(pool, 'error'), 'error handler is called on timeout'),
+    assert.rejects(task1, /Terminating worker thread/, 'task is aborted due to timeout'),
+    assert.rejects(task2, /Terminating worker thread/, 'task is aborted due to timeout')
   ]);
 });

--- a/test/pool-destroy.test.ts
+++ b/test/pool-destroy.test.ts
@@ -1,12 +1,13 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import Piscina from '..';
 
-test('can destroy pool while tasks are running', async (t: TestContext) => {
+test('can destroy pool while tasks are running', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   setImmediate(() => pool.destroy());
-  await t.assert.rejects(pool.run('while(1){}'), /Terminating worker thread/);
+
+  assert.rejects(pool.run('while(1){}'), /Terminating worker thread/);
 });

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -1,18 +1,15 @@
+import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 import { test } from 'node:test';
 import { once } from 'node:events';
-
-import type { TestContext } from 'node:test';
-
 import Piscina from '../dist';
 
 const nodeVersion = Number(process.versions.node.split('.')[0])
 
-test('workerCreate/workerDestroy should be emitted while managing worker lifecycle', async (t: TestContext) => {
+test('workerCreate/workerDestroy should be emitted while managing worker lifecycle', async () => {
   let index = 0;
   // Its expected to have one task get balanced twice due to the load balancer distribution
   // first task enters, its distributed; second is enqueued, once first is done, second is distributed and normalizes
-  t.plan(2);
   let newWorkers = 0;
   let destroyedWorkers = 0;
   const pool = new Piscina({
@@ -46,43 +43,42 @@ test('workerCreate/workerDestroy should be emitted while managing worker lifecyc
     signal
   }));
 
-  for (let n = 0; n < 10; n++) {
-    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
+  for (let n = 0; n < 5; n++) {
+    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))'));
   }
 
   controller.abort();
   await Promise.allSettled(tasks);
   await pool.close();
-  t.assert.strictEqual(destroyedWorkers, 4);
-  t.assert.strictEqual(newWorkers, 4);
+  assert.strictEqual(destroyedWorkers, 4);
+  assert.strictEqual(newWorkers, 4);
 });
 
-test('Explicit resource management (dispose)', { skip: nodeVersion !== 24 }, async (t: TestContext) => {
+test('Explicit resource management (dispose)', { skip: nodeVersion !== 24 }, async () => {
   const piscina = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
     minThreads: 1,
     concurrentTasksPerWorker: 1,
   });
-  
+
   {
     using pool = piscina;
     const tasks = [];
-
-    t.plan(1);
+;
     pool.once('close', () => {
-      t.assert.ok(true)
+      assert.ok(true);
     });
 
     for (let n = 0; n < 10; n++) {
-      tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
+      tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))'));
     }
   }
 
   await once(piscina, 'close');
-})
+});
 
-test('Explicit resource management (asyncDispose)', { skip: nodeVersion !== 24 }, async (t: TestContext) => {
+test('Explicit resource management (asyncDispose)', { skip: nodeVersion !== 24 }, async () => {
   const piscina = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -94,18 +90,17 @@ test('Explicit resource management (asyncDispose)', { skip: nodeVersion !== 24 }
     await using pool = piscina;
     const tasks = [];
 
-    t.plan(1);
     pool.once('close', () => {
-      t.assert.ok(true)
+      assert.ok(true);
     });
 
     for (let n = 0; n < 10; n++) {
-      tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
+      tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))'));
     }
   }
 })
 
-test('#805 - Concurrent Aborts', async (t: TestContext) => {
+test('#805 - Concurrent Aborts', async (t) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -115,15 +110,14 @@ test('#805 - Concurrent Aborts', async (t: TestContext) => {
 
   t.after(() => pool.close());
 
-  t.plan(2);
   const tasks = [];
   const controller = new AbortController();
   const controller2 = new AbortController();
   const controller3 = new AbortController();
 
-  tasks.push(t.assert.rejects(pool.run('new Promise(resolve => setTimeout(resolve, 1500))', { signal: controller.signal })));
-  tasks.push(t.assert.rejects(pool.run('new Promise(resolve => setTimeout(resolve, 1500))', { signal: controller2.signal })));
-  tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 1000))', { signal: controller3.signal }));
+  tasks.push(assert.rejects(pool.run('new Promise(resolve => setTimeout(resolve, 5))', { signal: controller.signal })));
+  tasks.push(assert.rejects(pool.run('new Promise(resolve => setTimeout(resolve, 5))', { signal: controller2.signal })));
+  tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))', { signal: controller3.signal }));
 
 
   controller.abort();

--- a/test/post-task.test.ts
+++ b/test/post-task.test.ts
@@ -1,83 +1,83 @@
-import { MessageChannel } from 'worker_threads';
-import { getAvailableParallelism } from '../dist/common';
-import Piscina from '..';
+import assert from 'node:assert';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { MessageChannel } from 'node:worker_threads';
+import { resolve } from 'node:path';
+import Piscina from '..';
+import { getAvailableParallelism } from '../dist/common';
 
-test('postTask() can transfer ArrayBuffer instances', async (t: TestContext) => {
+test('postTask() can transfer ArrayBuffer instances', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
 
   const ab = new ArrayBuffer(40);
   await pool.run({ ab }, { transferList: [ab] });
-  t.assert.strictEqual(pool.completed, 1);
-  t.assert.strictEqual(ab.byteLength, 0);
+  assert.strictEqual(pool.completed, 1);
+  assert.strictEqual(ab.byteLength, 0);
 });
 
-test('postTask() cannot clone build-in objects', async (t: TestContext) => {
+test('postTask() cannot clone build-in objects', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
 
   const obj = new MessageChannel().port1;
-  t.assert.rejects(pool.run({ obj }));
+  assert.rejects(pool.run({ obj }));
 });
 
-test('postTask() resolves with a rejection when the handler rejects', async (t: TestContext) => {
+test('postTask() resolves with a rejection when the handler rejects', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('Promise.reject(new Error("foo"))'), /foo/);
+  assert.rejects(pool.run('Promise.reject(new Error("foo"))'), /foo/);
 });
 
-test('postTask() resolves with a rejection when the handler throws', async (t: TestContext) => {
+test('postTask() resolves with a rejection when the handler throws', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('throw new Error("foo")'), /foo/);
+  assert.rejects(pool.run('throw new Error("foo")'), /foo/);
 });
 
-test('postTask() validates transferList', async (t: TestContext) => {
+test('postTask() validates transferList', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('0', { transferList: 42 as any }),
+  assert.rejects(pool.run('0', { transferList: 42 as any }),
     /transferList argument must be an Array/);
 });
 
-test('postTask() validates filename', async (t: TestContext) => {
+test('postTask() validates filename', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('0', { filename: 42 as any }),
+  assert.rejects(pool.run('0', { filename: 42 as any }),
     /filename argument must be a string/);
 });
 
-test('postTask() validates name', async (t: TestContext) => {
+test('postTask() validates name', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('0', { name: 42 as any }),
+  assert.rejects(pool.run('0', { name: 42 as any }),
     /name argument must be a string/);
 });
 
-test('postTask() validates abortSignal', async (t: TestContext) => {
+test('postTask() validates abortSignal', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run('0', { signal: 42 as any }),
+  assert.rejects(pool.run('0', { signal: 42 as any }),
     /signal argument must be an object/);
 });
 
-test('Piscina emits drain', async (t: TestContext) => {
+test('Piscina emits drain', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1
@@ -92,25 +92,23 @@ test('Piscina emits drain', async (t: TestContext) => {
 
   await Promise.all([pool.run('123'), pool.run('123'), pool.run('123')]);
 
-  t.assert.ok(drained);
-  t.assert.ok(!needsDrain);
+  assert.ok(drained);
+  assert.ok(!needsDrain);
 });
 
-test('Piscina exposes/emits needsDrain to true when capacity is exceeded', (t: TestContext, done) => {
+test('Piscina exposes/emits needsDrain to true when capacity is exceeded', (t, done) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxQueue: 3,
     maxThreads: 1
   });
 
-  t.plan(3);
-
   pool.once('drain', () => {
-    t.assert.ok(true);
+    assert.ok(true);
     done();
   });
   pool.once('needsDrain', () => {
-    t.assert.ok(true);
+    assert.ok(true);
   });
 
   pool.run('123');
@@ -118,71 +116,68 @@ test('Piscina exposes/emits needsDrain to true when capacity is exceeded', (t: T
   pool.run('123');
   pool.run('123');
 
-  t.assert.ok(pool.needsDrain);
+  assert.ok(pool.needsDrain);
 });
 
-test('Piscina can use async loaded workers', async (t: TestContext) => {
+test('Piscina can use async loaded workers', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-async.js')
   });
-  t.assert.strictEqual(await pool.run('1'), 1);
+
+  assert.strictEqual(await pool.run('1'), 1);
 });
 
-test('Piscina can use async loaded esm workers', {}, async (t: TestContext) => {
+test('Piscina can use async loaded esm workers', {}, async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/esm-async.mjs')
   });
-  t.assert.strictEqual(await pool.run('1'), 1);
+
+  assert.strictEqual(await pool.run('1'), 1);
 });
 
-test('Piscina.run options is correct type', async (t: TestContext) => {
+test('Piscina.run options is correct type', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.assert.rejects(pool.run(42, 1 as any), /options must be an object/);
+  assert.rejects(pool.run(42, 1 as any), /options must be an object/);
 });
 
-test('Piscina.maxThreads should return the max number of threads to be used (default)', (t: TestContext) => {
-  t.plan(1);
+test('Piscina.maxThreads should return the max number of threads to be used (default)', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   const maxThreads = getAvailableParallelism() * 1.5;
 
-  t.assert.strictEqual(pool.maxThreads, maxThreads);
+  assert.strictEqual(pool.maxThreads, maxThreads);
 });
 
-test('Piscina.minThreads should return the max number of threads to be used (custom)', (t: TestContext) => {
+test('Piscina.minThreads should return the max number of threads to be used (custom)', () => {
   const maxThreads = 3;
   const pool = new Piscina({
     maxThreads,
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
-  t.plan(1);
-
-  t.assert.strictEqual(pool.maxThreads, maxThreads);
+  assert.strictEqual(pool.maxThreads, maxThreads);
 });
 
-test('Piscina.minThreads should return the max number of threads to be used (default)', (t: TestContext) => {
+test('Piscina.minThreads should return the max number of threads to be used (default)', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   const minThreads = Math.max(Math.floor(getAvailableParallelism() / 2), 1);
 
-  t.plan(1);
-  t.assert.strictEqual(pool.minThreads, minThreads);
+  assert.strictEqual(pool.minThreads, minThreads);
 });
 
-test('Piscina.minThreads should return the max number of threads to be used (custom)', (t: TestContext) => {
+test('Piscina.minThreads should return the max number of threads to be used (custom)', () => {
   const minThreads = 2;
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads
   });
-  t.plan(1);
 
-  t.assert.strictEqual(pool.minThreads, minThreads);
+  assert.strictEqual(pool.minThreads, minThreads);
 });

--- a/test/simple-test.test.ts
+++ b/test/simple-test.test.ts
@@ -1,194 +1,194 @@
-import Piscina from '..';
+import assert from 'node:assert';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { EventEmitter } from 'node:events';
+import Piscina from '..';
 import { version } from '../package.json';
-import { pathToFileURL } from 'url';
-import { resolve } from 'path';
-import { EventEmitter } from 'events';
 
-test('Piscina is exposed on export', async (t: TestContext) => {
-  t.assert.strictEqual(Piscina.version, version);
+test('Piscina is exposed on export', () => {
+  assert.strictEqual(Piscina.version, version);
 });
 
-test('Piscina is exposed on itself', async (t: TestContext) => {
-  t.assert.strictEqual(Piscina.Piscina, Piscina);
+test('Piscina is exposed on itself', () => {
+  assert.strictEqual(Piscina.Piscina, Piscina);
 });
 
-test('Piscina.isWorkerThread has the correct value', async (t: TestContext) => {
-  t.assert.strictEqual(Piscina.isWorkerThread, false);
+test('Piscina.isWorkerThread has the correct value', () => {
+  assert.strictEqual(Piscina.isWorkerThread, false);
 });
 
-test('Piscina.isWorkerThread has the correct value (worker)', async (t: TestContext) => {
+test('Piscina.isWorkerThread has the correct value (worker)', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread.ts')
   });
   const result = await worker.run(null);
-  t.assert.strictEqual(result, 'done');
+  assert.strictEqual(result, 'done');
 });
 
-test('Piscina.isWorkerThread has the correct value (worker) with named import', async (t: TestContext) => {
+test('Piscina.isWorkerThread has the correct value (worker) with named import', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread-named-import.ts')
   });
   const result = await worker.run(null);
-  t.assert.strictEqual(result, 'done');
+  assert.strictEqual(result, 'done');
 });
 
-test('Piscina.isWorkerThread has the correct value (worker) with named import', async (t: TestContext) => {
+test('Piscina.isWorkerThread has the correct value (worker) with named import', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-isworkerthread-named-import.ts')
   });
   const result = await worker.run(null);
-  t.assert.strictEqual(result, 'done');
+  assert.strictEqual(result, 'done');
 });
 
-test('Piscina instance is an EventEmitter', async (t: TestContext) => {
+test('Piscina instance is an EventEmitter', async () => {
   const piscina = new Piscina();
-  t.assert.ok(piscina instanceof EventEmitter);
+  assert.ok(piscina instanceof EventEmitter);
 });
 
-test('Piscina constructor options are correctly set', async (t: TestContext) => {
+test('Piscina constructor options are correctly set', async () => {
   const piscina = new Piscina({
     minThreads: 10,
     maxThreads: 20,
     maxQueue: 30
   });
 
-  t.assert.strictEqual(piscina.options.minThreads, 10);
-  t.assert.strictEqual(piscina.options.maxThreads, 20);
-  t.assert.strictEqual(piscina.options.maxQueue, 30);
+  assert.strictEqual(piscina.options.minThreads, 10);
+  assert.strictEqual(piscina.options.maxThreads, 20);
+  assert.strictEqual(piscina.options.maxQueue, 30);
 });
 
-test('trivial eval() handler works', async (t: TestContext) => {
+test('trivial eval() handler works', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   const result = await worker.run('42');
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('async eval() handler works', async (t: TestContext) => {
+test('async eval() handler works', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
   const result = await worker.run('Promise.resolve(42)');
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('filename can be provided while posting', async (t: TestContext) => {
+test('filename can be provided while posting', async () => {
   const worker = new Piscina();
   const result = await worker.run(
     'Promise.resolve(42)',
     { filename: resolve(__dirname, 'fixtures/eval.js') });
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('filename can be null when initially provided', async (t: TestContext) => {
+test('filename can be null when initially provided', async () => {
   const worker = new Piscina({ filename: null });
   const result = await worker.run(
     'Promise.resolve(42)',
     { filename: resolve(__dirname, 'fixtures/eval.js') });
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('filename must be provided while posting', async (t: TestContext) => {
+test('filename must be provided while posting', () => {
   const worker = new Piscina();
-  t.assert.rejects(worker.run('doesn’t matter'),
+  assert.rejects(worker.run('doesn’t matter'),
     /filename must be provided to run\(\) or in options object/);
 });
 
-test('passing env to workers works', async (t: TestContext) => {
+test('passing env to workers works', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     env: { A: 'foo' }
   });
 
   const env = await pool.run('({...process.env})');
-  t.assert.deepStrictEqual(env, { A: 'foo' });
+  assert.deepStrictEqual(env, { A: 'foo' });
 });
 
-test('passing argv to workers works', async (t: TestContext) => {
+test('passing argv to workers works', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     argv: ['a', 'b', 'c']
   });
 
   const env = await pool.run('process.argv.slice(2)');
-  t.assert.deepStrictEqual(env, ['a', 'b', 'c']);
+  assert.deepStrictEqual(env, ['a', 'b', 'c']);
 });
 
-test('passing execArgv to workers works', async (t: TestContext) => {
+test('passing execArgv to workers works', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     execArgv: ['--no-warnings']
   });
 
   const env = await pool.run('process.execArgv');
-  t.assert.deepStrictEqual(env, ['--no-warnings']);
+  assert.deepStrictEqual(env, ['--no-warnings']);
 });
 
-test('passing valid workerData works', async (t: TestContext) => {
+test('passing valid workerData works', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
     workerData: 'ABC'
   });
-  t.assert.strictEqual(Piscina.workerData, undefined);
+  assert.strictEqual(Piscina.workerData, undefined);
 
   await pool.run(null);
 });
 
-test('passing valid workerData works with named import', async (t: TestContext) => {
+test('passing valid workerData works with named import', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-workerdata-named-import.ts'),
     workerData: 'ABC'
   });
-  t.assert.strictEqual(Piscina.workerData, undefined);
+  assert.strictEqual(Piscina.workerData, undefined);
 
   await pool.run(null);
 });
 
-test('passing valid workerData works with named import', async (t: TestContext) => {
+test('passing valid workerData works with named import', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/simple-workerdata-named-import.ts'),
     workerData: 'ABC'
   });
-  t.assert.strictEqual(Piscina.workerData, undefined);
+  assert.strictEqual(Piscina.workerData, undefined);
 
   await pool.run(null);
 });
 
-test('passing invalid workerData does not work', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina(({
+test('passing invalid workerData does not work', () => {
+  assert.throws(() => new Piscina(({
     filename: resolve(__dirname, 'fixtures/simple-workerdata.ts'),
     workerData: {
       hello () {}
     }
-  }) as any), /could not be cloned./);
+  })), /could not be cloned./);
 });
 
-test('filename can be a file:// URL', async (t: TestContext) => {
+test('filename can be a file:// URL', async () => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')).href
   });
   const result = await worker.run('42');
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('filename can be a file:// URL to an ESM module', {}, async (t: TestContext) => {
+test('filename can be a file:// URL to an ESM module', {}, async () => {
   const worker = new Piscina({
     filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')).href
   });
   const result = await worker.run('42');
-  t.assert.strictEqual(result, 42);
+  assert.strictEqual(result, 42);
 });
 
-test('duration and utilization calculations work', async (t: TestContext) => {
+test('duration and utilization calculations work', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
 
   // Initial utilization is always 0
-  t.assert.strictEqual(worker.utilization, 0);
+  assert.strictEqual(worker.utilization, 0);
 
   await Promise.all([
     worker.run('42'),
@@ -199,11 +199,11 @@ test('duration and utilization calculations work', async (t: TestContext) => {
   // utilization is going to be some non-deterministic value
   // between 0 and 1. It should not be zero at this point
   // because tasks have run, but it should also never be 1
-  t.assert.ok(worker.utilization > 0);
-  t.assert.ok(worker.utilization < 1);
+  assert.ok(worker.utilization > 0);
+  assert.ok(worker.utilization < 1);
 
   // Duration must be non-zero.
-  t.assert.ok(worker.duration > 0);
+  assert.ok(worker.duration > 0);
 });
 
 test('run works also', async () => {
@@ -214,23 +214,23 @@ test('run works also', async () => {
   await worker.run(42);
 });
 
-test('named tasks work', async (t: TestContext) => {
+test('named tasks work', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/multiple.js')
   });
 
-  t.assert.strictEqual(await worker.run({}, { name: 'a' }), 'a');
-  t.assert.strictEqual(await worker.run({}, { name: 'b' }), 'b');
-  t.assert.strictEqual(await worker.run({}), 'a');
+  assert.strictEqual(await worker.run({}, { name: 'a' }), 'a');
+  assert.strictEqual(await worker.run({}, { name: 'b' }), 'b');
+  assert.strictEqual(await worker.run({}), 'a');
 });
 
-test('named tasks work', async (t: TestContext) => {
+test('named tasks work', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/multiple.js'),
     name: 'b'
   });
 
-  t.assert.strictEqual(await worker.run({}, { name: 'a' }), 'a');
-  t.assert.strictEqual(await worker.run({}, { name: 'b' }), 'b');
-  t.assert.strictEqual(await worker.run({}), 'b');
+  assert.strictEqual(await worker.run({}, { name: 'a' }), 'a');
+  assert.strictEqual(await worker.run({}, { name: 'b' }), 'b');
+  assert.strictEqual(await worker.run({}), 'b');
 });

--- a/test/task-queue.test.ts
+++ b/test/task-queue.test.ts
@@ -1,17 +1,17 @@
-import Piscina, { PiscinaTask, TaskQueue } from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import Piscina, { PiscinaTask, TaskQueue } from '..';
 
-test('will put items into a task queue until they can run', async (t: TestContext) => {
+test('will put items into a task queue until they can run', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 2,
     maxThreads: 3
   });
 
-  t.assert.strictEqual(pool.threads.length, 2);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.queueSize, 0);
 
   const buffers = [
     new Int32Array(new SharedArrayBuffer(4)),
@@ -23,20 +23,20 @@ test('will put items into a task queue until they can run', async (t: TestContex
   const results = [];
 
   results.push(pool.run(buffers[0]));
-  t.assert.strictEqual(pool.threads.length, 2);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.queueSize, 0);
 
   results.push(pool.run(buffers[1]));
-  t.assert.strictEqual(pool.threads.length, 2);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.queueSize, 0);
 
   results.push(pool.run(buffers[2]));
-  t.assert.strictEqual(pool.threads.length, 3);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 3);
+  assert.strictEqual(pool.queueSize, 0);
 
   results.push(pool.run(buffers[3]));
-  t.assert.strictEqual(pool.threads.length, 3);
-  t.assert.strictEqual(pool.queueSize, 1);
+  assert.strictEqual(pool.threads.length, 3);
+  assert.strictEqual(pool.queueSize, 1);
 
   for (const buffer of buffers) {
     Atomics.store(buffer, 0, 1);
@@ -44,12 +44,12 @@ test('will put items into a task queue until they can run', async (t: TestContex
   }
 
   await results[0];
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.queueSize, 0);
 
   await Promise.all(results);
 });
 
-test('will reject items over task queue limit', async (t: TestContext) => {
+test('will reject items over task queue limit', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 0,
@@ -57,26 +57,26 @@ test('will reject items over task queue limit', async (t: TestContext) => {
     maxQueue: 2
   });
 
-  t.assert.strictEqual(pool.threads.length, 0);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 1);
+  assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 1);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 2);
+  assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 2);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Task queue is at limit/);
+  assert.rejects(pool.run('while (true) {}'), /Task queue is at limit/);
   await pool.destroy();
 });
 
-test('will reject items when task queue is unavailable', async (t: TestContext) => {
+test('will reject items when task queue is unavailable', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 0,
@@ -84,18 +84,18 @@ test('will reject items when task queue is unavailable', async (t: TestContext) 
     maxQueue: 0
   });
 
-  t.assert.strictEqual(pool.threads.length, 0);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
+  assert.rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
-test('will reject items when task queue is unavailable (fixed thread count)', async (t: TestContext) => {
+test('will reject items when task queue is unavailable (fixed thread count)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 1,
@@ -103,18 +103,18 @@ test('will reject items when task queue is unavailable (fixed thread count)', as
     maxQueue: 0
   });
 
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run('while (true) {}'), /Terminating worker thread/);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
+  assert.rejects(pool.run('while (true) {}'), /No task queue available and all Workers are busy/);
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (both tests blocking)', async (t: TestContext) => {
+test('tasks can share a Worker if requested (both tests blocking)', async (t) => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 0,
@@ -123,21 +123,21 @@ test('tasks can share a Worker if requested (both tests blocking)', async (t: Te
     concurrentTasksPerWorker: 2
   });
 
-  t.assert.strictEqual(pool.threads.length, 0);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.rejects(pool.run(new Int32Array(new SharedArrayBuffer(4))));
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (one test finishes)', async (t: TestContext) => {
+test('tasks can share a Worker if requested (one test finishes)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.js'),
     minThreads: 0,
@@ -151,31 +151,31 @@ test('tasks can share a Worker if requested (one test finishes)', async (t: Test
     new Int32Array(new SharedArrayBuffer(4))
   ];
 
-  t.assert.strictEqual(pool.threads.length, 0);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(pool.queueSize, 0);
 
   const firstTask = pool.run(buffers[0]);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
-  t.assert.rejects(pool.run(
-    'new Promise((resolve) => setTimeout(resolve, 1000000))',
+  assert.rejects(pool.run(
+    'new Promise((resolve) => setTimeout(resolve, 5))',
     { filename: resolve(__dirname, 'fixtures/eval.js') })
   , /Terminating worker thread/);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   Atomics.store(buffers[0], 0, 1);
   Atomics.notify(buffers[0], 0, 1);
 
   await firstTask;
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   await pool.destroy();
 });
 
-test('tasks can share a Worker if requested (both tests finish)', async (t: TestContext) => {
+test('tasks can share a Worker if requested (both tests finish)', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/wait-for-notify.ts'),
     minThreads: 1,
@@ -189,16 +189,16 @@ test('tasks can share a Worker if requested (both tests finish)', async (t: Test
     new Int32Array(new SharedArrayBuffer(4))
   ];
 
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   const firstTask = pool.run(buffers[0]);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   const secondTask = pool.run(buffers[1]);
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 
   Atomics.store(buffers[0], 0, 1);
   Atomics.store(buffers[1], 0, 1);
@@ -208,15 +208,15 @@ test('tasks can share a Worker if requested (both tests finish)', async (t: Test
   Atomics.wait(buffers[1], 0, 1);
 
   await firstTask;
-  t.assert.strictEqual(buffers[0][0], -1);
+  assert.strictEqual(buffers[0][0], -1);
   await secondTask;
-  t.assert.strictEqual(buffers[1][0], -1);
+  assert.strictEqual(buffers[1][0], -1);
 
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.queueSize, 0);
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.queueSize, 0);
 });
 
-test('custom task queue works', async (t: TestContext) => {
+test('custom task queue works', async () => {
   let sizeCalled : boolean = false;
   let shiftCalled : boolean = false;
   let pushCalled : boolean = false;
@@ -238,11 +238,11 @@ test('custom task queue works', async (t: TestContext) => {
       pushCalled = true;
       this.tasks.push(task);
 
-      t.assert.ok(Piscina.queueOptionsSymbol in task);
+      assert.ok(Piscina.queueOptionsSymbol in task);
       if ((task as any).task.a === 3) {
-        t.assert.strictEqual(task[Piscina.queueOptionsSymbol], null);
+        assert.strictEqual(task[Piscina.queueOptionsSymbol], null);
       } else {
-        t.assert.strictEqual(task[Piscina.queueOptionsSymbol].option,
+        assert.strictEqual(task[Piscina.queueOptionsSymbol].option,
           (task as any).task.a);
       }
     }
@@ -271,11 +271,11 @@ test('custom task queue works', async (t: TestContext) => {
     pool.run({ a: 3 }) // No queueOptionsSymbol attached
   ]);
 
-  t.assert.strictEqual(ret[0].a, 1);
-  t.assert.strictEqual(ret[1].a, 2);
-  t.assert.strictEqual(ret[2].a, 3);
+  assert.strictEqual(ret[0].a, 1);
+  assert.strictEqual(ret[1].a, 2);
+  assert.strictEqual(ret[2].a, 3);
 
-  t.assert.ok(sizeCalled);
-  t.assert.ok(pushCalled);
-  t.assert.ok(shiftCalled);
+  assert.ok(sizeCalled);
+  assert.ok(pushCalled);
+  assert.ok(shiftCalled);
 });

--- a/test/test-is-buffer-transferred.test.ts
+++ b/test/test-is-buffer-transferred.test.ts
@@ -4,7 +4,10 @@ import { resolve } from 'node:path';
 import Piscina from '..';
 
 function wait () {
-  return new Promise((resolve) => setTimeout(resolve, 5));
+  // Timeout here should be little bit longer
+  // than in the worker timeout
+  // to ensure there are no flaky tests
+  return new Promise((resolve) => setTimeout(resolve, 10));
 }
 
 test('transferable objects must be transferred', async () => {

--- a/test/test-is-buffer-transferred.test.ts
+++ b/test/test-is-buffer-transferred.test.ts
@@ -1,13 +1,13 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import Piscina from '..';
 
 function wait () {
-  return new Promise((resolve) => setTimeout(resolve, 1500));
+  return new Promise((resolve) => setTimeout(resolve, 5));
 }
 
-test('transferable objects must be transferred', async (t: TestContext) => {
+test('transferable objects must be transferred', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/send-buffer-then-get-length.js'),
     atomics: 'disabled'
@@ -15,10 +15,10 @@ test('transferable objects must be transferred', async (t: TestContext) => {
   await pool.run({}, { name: 'send' });
   await wait();
   const after = await pool.run({}, { name: 'get' });
-  t.assert.strictEqual(after, 0);
+  assert.strictEqual(after, 0);
 });
 
-test('objects that implement transferable must be transferred', async (t: TestContext) => {
+test('objects that implement transferable must be transferred', async () => {
   const pool = new Piscina({
     filename: resolve(
       __dirname,
@@ -29,5 +29,5 @@ test('objects that implement transferable must be transferred', async (t: TestCo
   await pool.run({}, { name: 'send' });
   await wait();
   const after = await pool.run({}, { name: 'get' });
-  t.assert.strictEqual(after, 0);
+  assert.strictEqual(after, 0);
 });

--- a/test/test-resourcelimits.test.ts
+++ b/test/test-resourcelimits.test.ts
@@ -1,9 +1,9 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
+import Piscina from '..';
 
-test('resourceLimits causes task to reject', async (t: TestContext) => {
+test('resourceLimits causes task to reject', async () => {
   const worker = new Piscina({
     filename: resolve(__dirname, 'fixtures/resource-limits.js'),
     resourceLimits: {
@@ -27,9 +27,9 @@ test('resourceLimits causes task to reject', async (t: TestContext) => {
     // now.
   });
   const limits : any = worker.options.resourceLimits;
-  t.assert.strictEqual(limits.maxOldGenerationSizeMb, 16);
-  t.assert.strictEqual(limits.maxYoungGenerationSizeMb, 4);
-  t.assert.strictEqual(limits.codeRangeSizeMb, 16);
-  t.assert.rejects(worker.run(null),
+  assert.strictEqual(limits.maxOldGenerationSizeMb, 16);
+  assert.strictEqual(limits.maxYoungGenerationSizeMb, 4);
+  assert.strictEqual(limits.codeRangeSizeMb, 16);
+  assert.rejects(worker.run(null),
     /Worker terminated due to reaching memory limit: JS heap out of memory/);
 });

--- a/test/test-uncaught-exception-from-handler.test.ts
+++ b/test/test-uncaught-exception-from-handler.test.ts
@@ -1,28 +1,28 @@
-import Piscina from '..';
+import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-import { resolve } from 'path';
-import { once } from 'events';
+import { resolve } from 'node:path';
+import { once } from 'node:events';
+import Piscina from '..';
 
-test('uncaught exception resets Worker', async (t: TestContext)=> {
+test('uncaught exception resets Worker', ()=> {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-  await t.assert.rejects(pool.run('throw new Error("not_caught")'), /not_caught/);
+  assert.rejects(pool.run('throw new Error("not_caught")'), /not_caught/);
 });
 
-test('uncaught exception in immediate resets Worker', async (t: TestContext)=> {
+test('uncaught exception in immediate resets Worker', ()=> {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js')
   });
-  await t.assert.rejects(
+  assert.rejects(
     pool.run(`
       setImmediate(() => { throw new Error("not_caught") });
       new Promise(() => {}) /* act as if we were doing some work */
     `), /not_caught/);
 });
 
-test('uncaught exception in immediate after task yields error event', async (t: TestContext) => {
+test('uncaught exception in immediate after task yields error event', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1,
@@ -32,32 +32,32 @@ test('uncaught exception in immediate after task yields error event', async (t: 
   const errorEvent : Promise<Error[]> = once(pool, 'error');
 
   const taskResult = pool.run(`
-    setTimeout(() => { throw new Error("not_caught") }, 500);
+    setTimeout(() => { throw new Error("not_caught") }, 5);
     42
   `);
 
-  t.assert.strictEqual(await taskResult, 42);
+  assert.strictEqual(await taskResult, 42);
 
   // Hack a bit to make sure we get the 'exit'/'error' events.
-  t.assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.threads.length, 1);
   pool.threads[0].ref();
 
   // This is the main assertion here.
-  t.assert.strictEqual((await errorEvent)[0].message, 'not_caught');
+  assert.strictEqual((await errorEvent)[0].message, 'not_caught');
 });
 
-test('exiting process resets worker', async (t: TestContext) => {
+test('exiting process resets worker', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 1
   });
   const originalThreadId = pool.threads[0].threadId;
-  await t.assert.rejects(pool.run('process.exit(1);'), /worker exited with code: 1/);
+  await assert.rejects(pool.run('process.exit(1);'), /worker exited with code: 1/);
   const newThreadId = pool.threads[0].threadId;
-  t.assert.notStrictEqual(originalThreadId, newThreadId);
+  assert.notStrictEqual(originalThreadId, newThreadId);
 });
 
-test('exiting process in immediate after task errors next task and resets worker', async (t: TestContext) => {
+test('exiting process in immediate after task errors next task and resets worker', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval-async.js'),
     minThreads: 1
@@ -65,23 +65,23 @@ test('exiting process in immediate after task errors next task and resets worker
 
   const originalThreadId = pool.threads[0].threadId;
   const taskResult = await pool.run(`
-    setTimeout(() => { process.exit(1); }, 50);
+    setTimeout(() => { process.exit(1); }, 5);
     42
   `);
-  t.assert.strictEqual(taskResult, 42);
+  assert.strictEqual(taskResult, 42);
 
-  await t.assert.rejects(pool.run(`
+  await assert.rejects(pool.run(`
   'use strict';
 
-  const { promisify } = require('util');
+  const { promisify } = require('node:util');
   const sleep = promisify(setTimeout);
   async function _() {
-    await sleep(1000);
+    await sleep(5);
     return 42
   }
   _();
   `), /worker exited with code: 1/);
   const secondThreadId = pool.threads[0].threadId;
 
-  t.assert.notStrictEqual(originalThreadId, secondThreadId);
+  assert.notStrictEqual(originalThreadId, secondThreadId);
 });

--- a/test/thread-count.test.ts
+++ b/test/thread-count.test.ts
@@ -1,11 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
 import { resolve } from 'node:path';
 import { cpus } from 'node:os';
 import { once } from 'node:events';
 import Piscina from '..';
-import { test } from 'node:test';
-import type { TestContext } from 'node:test';
 
-test('will start with minThreads and max out at maxThreads', async (t: TestContext) => {
+test('will start with minThreads and max out at maxThreads', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 2,
@@ -18,65 +18,67 @@ test('will start with minThreads and max out at maxThreads', async (t: TestConte
     counter++;
   });
 
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
 
-  t.assert.rejects(pool.run('while(true) {}'));
-  t.assert.rejects(pool.run('while(true) {}'));
+  assert.rejects(pool.run('while(true) {}'));
+  assert.rejects(pool.run('while(true) {}'));
 
   // #3
-  t.assert.rejects(pool.run('while(true) {}'));
+  assert.rejects(pool.run('while(true) {}'));
   await once(pool, 'workerCreate');
 
   // #4
-  t.assert.rejects(pool.run('while(true) {}'));
+  assert.rejects(pool.run('while(true) {}'));
   await once(pool, 'workerCreate');
 
   // #4 - as spawn does not happen synchronously anymore, we wait for the signal once more
-  t.assert.rejects(pool.run('while(true) {}'));
+  assert.rejects(pool.run('while(true) {}'));
   await once(pool, 'workerCreate');
 
-  t.assert.strictEqual(pool.threads.length, 4);
+  assert.strictEqual(pool.threads.length, 4);
   await pool.destroy();
-  t.assert.strictEqual(pool.threads.length, 0);
-  t.assert.strictEqual(counter, 4);
+  assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(counter, 4);
 });
 
-test('low maxThreads sets minThreads', async (t: TestContext) => {
+test('low maxThreads sets minThreads', () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     maxThreads: 1
   });
-  t.assert.strictEqual(pool.threads.length, 1);
-  t.assert.strictEqual(pool.options.minThreads, 1);
-  t.assert.strictEqual(pool.options.maxThreads, 1);
+
+  assert.strictEqual(pool.threads.length, 1);
+  assert.strictEqual(pool.options.minThreads, 1);
+  assert.strictEqual(pool.options.maxThreads, 1);
 });
 
 test('high minThreads sets maxThreads', {
   skip: cpus().length > 8
-}, async (t: TestContext) => {
+}, () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 16
   });
-  t.assert.strictEqual(pool.threads.length, 16);
-  t.assert.strictEqual(pool.options.minThreads, 16);
-  t.assert.strictEqual(pool.options.maxThreads, 16);
+
+  assert.strictEqual(pool.threads.length, 16);
+  assert.strictEqual(pool.options.minThreads, 16);
+  assert.strictEqual(pool.options.maxThreads, 16);
 });
 
-test('conflicting min/max threads is error', async (t: TestContext) => {
-  t.assert.throws(() => new Piscina({
+test('conflicting min/max threads is error', () => {
+  assert.throws(() => new Piscina({
     minThreads: 16,
     maxThreads: 8
   }), /options.minThreads and options.maxThreads must not conflict/);
 });
 
-test('thread count should be 0 upon destruction', async (t: TestContext) => {
+test('thread count should be 0 upon destruction', async () => {
   const pool = new Piscina({
     filename: resolve(__dirname, 'fixtures/eval.js'),
     minThreads: 2,
     maxThreads: 4
   });
-  t.assert.strictEqual(pool.threads.length, 2);
+  assert.strictEqual(pool.threads.length, 2);
   await pool.destroy();
-  t.assert.strictEqual(pool.threads.length, 0);
+  assert.strictEqual(pool.threads.length, 0);
 });

--- a/test/workers.test.ts
+++ b/test/workers.test.ts
@@ -1,15 +1,12 @@
-import { resolve } from 'node:path';
-
+import assert from 'node:assert';
 import { test } from 'node:test';
-import type { TestContext } from 'node:test';
-
+import { resolve } from 'node:path';
 import Piscina from '../dist';
 
-test('workers are marked as destroyed if destroyed', async (t: TestContext) => {
+test('workers are marked as destroyed if destroyed', async () => {
   let index = 0;
   // Its expected to have one task get balanced twice due to the load balancer distribution
   // first task enters, its distributed; second is enqueued, once first is done, second is distributed and normalizes
-  t.plan(4);
   let workersFirstRound = [];
   let workersSecondRound = [];
   const pool = new Piscina({
@@ -45,13 +42,13 @@ test('workers are marked as destroyed if destroyed', async (t: TestContext) => {
   }));
 
   for (let n = 0; n < 5; n++) {
-    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 500))'));
+    tasks.push(pool.run('new Promise(resolve => setTimeout(resolve, 5))'));
   }
 
   controller.abort();
   await Promise.allSettled(tasks);
-  t.assert.notStrictEqual(workersFirstRound, workersSecondRound);
-  t.assert.strictEqual(workersFirstRound.length, 2);
-  t.assert.ok(workersFirstRound[0].destroyed);
-  t.assert.ok(!workersFirstRound[0].terminating);
+  assert.notStrictEqual(workersFirstRound, workersSecondRound);
+  assert.strictEqual(workersFirstRound.length, 2);
+  assert.ok(workersFirstRound[0].destroyed);
+  assert.ok(!workersFirstRound[0].terminating);
 });


### PR DESCRIPTION
## Description

- Reduce sleeping time for some test
- Remove such as possible type casting
- Use assert module instead of test connect assertion wich is uncommon way to make test

## Result

- **Before** 23s
- **After with test coverage** 12s
- **After without test coverage** 9s

> That on my MacBook M1 on node v20