### PR TITLE
fix: onWorkerMessage gets skipped in Jest environment 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,14 @@ class ThreadPool {
     }
 
     function onWorkerMessage (this: ThreadPool, message: any) {
-      message instanceof Object && READY in message ? onWorkerReady() : onEventMessage.call(this, message);
+      const isReadyMessage =
+        (message instanceof Object && READY in message) ||
+        (typeof message === 'object' && message !== null && READY in message);
+      if (isReadyMessage) {
+        onWorkerReady();
+      } else {
+        onEventMessage.call(this, message);
+      }
     }
 
     function onWorkerError (this: ThreadPool, err: Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -995,8 +995,14 @@ export default class Piscina<Exports extends Record<string, (payload: any) => an
 }
 
 export const move = Piscina.move;
-export const isWorkerThread = Piscina.isWorkerThread;
-export const workerData = Piscina.workerData;
+Object.defineProperty(module.exports, 'isWorkerThread', {
+  get: () => commonState.isWorkerThread,
+  enumerable: true
+});
+Object.defineProperty(module.exports, 'workerData', {
+  get: () => commonState.workerData,
+  enumerable: true
+});
 
 export {
   Piscina,


### PR DESCRIPTION
Repro: Set up a jest test utilizing a piscina workerpool with min:0 max: N. When the first worker gets set up, it fails to execute the task because the onWorkerMessage check for `message instanceOf Object` fails. 