### PR TITLE
docs: Update Fastify listen() calls to use { port: 3000 } in docs and examples

### DIFF
--- a/docs/docs/examples/react-ssr.mdx
+++ b/docs/docs/examples/react-ssr.mdx
@@ -228,7 +228,7 @@ fastify.get('/', async () => fastify.runTask({ name: 'James' }));
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }
@@ -267,7 +267,7 @@ fastify.get('/', async () => fastify.runTask({ name: 'James' }, { name: 'renderP
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }
@@ -321,7 +321,7 @@ fastify.get('/', async () => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/react-ssr/pooled.js
+++ b/examples/react-ssr/pooled.js
@@ -16,7 +16,7 @@ fastify.get('/', async () => fastify.run({ name: 'James' }));
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/react-ssr/unpooled.js
+++ b/examples/react-ssr/unpooled.js
@@ -27,7 +27,7 @@ fastify.get('/', async () => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/server/async-sleep-pooled.js
+++ b/examples/server/async-sleep-pooled.js
@@ -18,7 +18,7 @@ fastify.get('/', () => fastify.run());
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/server/async-sleep-unpooled.js
+++ b/examples/server/async-sleep-unpooled.js
@@ -13,7 +13,7 @@ fastify.get('/', async () => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/server/sync-sleep-pooled.js
+++ b/examples/server/sync-sleep-pooled.js
@@ -18,7 +18,7 @@ fastify.get('/', () => fastify.run());
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }

--- a/examples/server/sync-sleep-unpooled.js
+++ b/examples/server/sync-sleep-unpooled.js
@@ -14,7 +14,7 @@ fastify.get('/', async () => {
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000);
+    await fastify.listen({ port: 3000 });
   } catch (err) {
     process.exit(1);
   }


### PR DESCRIPTION
## Overview

Examples that use [fastify](https://github.com/fastify/fastify) were failing because Fastify’s current listen() API requires an options object like fastify.listen({ port: 3000 }), the old fastify.listen(3000) form is no longer valid in the target version. The change makes the examples/docs compatible with the current Fastify API and avoids runtime failures.

## Category

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (refactoring, dependency updates, etc.)

## Contribution Checklist

<!-- Please verify the following before submitting: -->

- [x] I have reviewed the [guidelines](../CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] My code adheres to the project's style and conventions.
- [ ] I have added tests to cover my changes.
- [x] All tests passed locally.
- [x] I have updated relevant documentation.

## DCO Sign-off

- [x] I certify that I have the right to submit this contribution under the open source license ([DCO 1.1](../CONTRIBUTING.md#developers-certificate-of-origin-11)).
