### PR TITLE
fix: eagerly spawn workers up to maxThreads on cold-pool burst

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -563,6 +563,13 @@ class ThreadPool {
         }
       } else {
         this.taskQueue.push(taskInfo);
+        // Eagerly spawn additional workers up to maxThreads while there is
+        // queued work. Without this, a cold pool serializes the initial burst
+        // because the next spawn only happens once the first worker is ready.
+        // The balancer still owns distribution once workers become available.
+        if (this.workers.size < this.options.maxThreads) {
+          this._addNewWorker();
+        }
       }
 
       this._maybeDrain();

--- a/test/thread-count.test.ts
+++ b/test/thread-count.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { resolve } from 'node:path';
 import { cpus } from 'node:os';
-import { once } from 'node:events';
 import Piscina from '..';
 
 test('will start with minThreads and max out at maxThreads', async () => {
@@ -13,32 +12,58 @@ test('will start with minThreads and max out at maxThreads', async () => {
     concurrentTasksPerWorker: 1
   });
   let counter = 0;
-
-  pool.on('workerCreate', () => {
-    counter++;
+  const created = new Promise<void>(resolve => {
+    pool.on('workerCreate', () => {
+      counter++;
+      if (counter === 4) resolve();
+    });
   });
 
   assert.strictEqual(pool.threads.length, 2);
-
   assert.rejects(pool.run('while(true) {}'));
+  assert.strictEqual(pool.threads.length, 2);
   assert.rejects(pool.run('while(true) {}'));
-
-  // #3
+  assert.strictEqual(pool.threads.length, 2);
   assert.rejects(pool.run('while(true) {}'));
-  await once(pool, 'workerCreate');
-
-  // #4
+  assert.strictEqual(pool.threads.length, 3);
   assert.rejects(pool.run('while(true) {}'));
-  await once(pool, 'workerCreate');
-
-  // #4 - as spawn does not happen synchronously anymore, we wait for the signal once more
-  assert.rejects(pool.run('while(true) {}'));
-  await once(pool, 'workerCreate');
-
   assert.strictEqual(pool.threads.length, 4);
+  assert.rejects(pool.run('while(true) {}'));
+  assert.strictEqual(pool.threads.length, 4);
+
+  await created;
+  assert.strictEqual(counter, 4);
+
   await pool.destroy();
   assert.strictEqual(pool.threads.length, 0);
-  assert.strictEqual(counter, 4);
+});
+
+test('cold pool spawns workers eagerly up to maxThreads on initial burst', async () => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/sleep.js'),
+    minThreads: 0,
+    maxThreads: 4,
+    concurrentTasksPerWorker: 1
+  });
+
+  assert.strictEqual(pool.threads.length, 0);
+
+  // Submit 4 tasks synchronously; all 4 workers should be spawning before
+  // any of them finishes initializing.
+  const tasks = [
+    pool.run({ time: 50 }),
+    pool.run({ time: 50 }),
+    pool.run({ time: 50 }),
+    pool.run({ time: 50 })
+  ];
+  assert.strictEqual(pool.threads.length, 4);
+
+  // A 5th task must not spawn another worker since we're at maxThreads.
+  const overflow = pool.run({ time: 50 });
+  assert.strictEqual(pool.threads.length, 4);
+
+  await Promise.all([...tasks, overflow]);
+  await pool.destroy();
 });
 
 test('low maxThreads sets minThreads', () => {


### PR DESCRIPTION
## Overview

Fix regression described in https://github.com/piscinajs/piscina/issues/1037 by restoring the eager spawn on cold pool.

## Category

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (refactoring, dependency updates, etc.)

## Contribution Checklist

<!-- Please verify the following before submitting: -->

- [X] I have reviewed the [guidelines](../CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [X] My code adheres to the project's style and conventions.
- [X] I have added tests to cover my changes.
- [X] All tests passed locally.
- [X] I have updated relevant documentation.

## DCO Sign-off

- [X] I certify that I have the right to submit this contribution under the open source license ([DCO 1.1](../CONTRIBUTING.md#developers-certificate-of-origin-11)).
