### PR TITLE
docs: fix typos in docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Declaring formal releases remains the prerogative of the project maintainer.
 ## Previous Versions
 Every version of Piscina has its own branch. All Piscina related changes should be based on the corresponding branch.
 
-Piscina's adhere to one active release line and a maintanance release line within a single year, rotating on a yearly basis.
+Piscina's adhere to one active release line and a maintenance release line within a single year, rotating on a yearly basis.
 
 Version	| Branch | Status
 ------- | ------ | ------

--- a/README.md
+++ b/README.md
@@ -419,10 +419,10 @@ This class extends [`EventEmitter`][] from Node.js.
   - `atomics`: (`sync` | `async` | `disabled`) Use the [`Atomics`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics) API for faster communication
     between threads. This is on by default. You can disable `Atomics` globally by
     setting the environment variable `PISCINA_DISABLE_ATOMICS` to `1` .
-    If `atomics` is `sync`, it will cause to pause threads (stoping all execution)
+    If `atomics` is `sync`, it will cause to pause threads (stopping all execution)
     between tasks. Ideally, threads should wait for all operations to finish before
     returning control to the main thread (avoid having open handles within a thread). If still want to have the possibility
-    of having open handles or handle asynchrnous tasks, you can set the environment variable `PISCINA_ENABLE_ASYNC_ATOMICS` to `1` or setting `options.atomics` to `async`.
+    of having open handles or handle asynchronous tasks, you can set the environment variable `PISCINA_ENABLE_ASYNC_ATOMICS` to `1` or setting `options.atomics` to `async`.
 
   > **Note**: The `async` mode comes with performance penalties and can lead to undesired behaviour if open handles are not tracked correctly.
 
@@ -690,8 +690,8 @@ Provides the current version of this library as a semver string.
 
 By default, any value returned by a worker function will be cloned when
 returned back to the Piscina pool, even if that object is capable of
-being transfered. The `Piscina.move()` method can be used to wrap and
-mark transferable values such that they will by transfered rather than
+being transferred. The `Piscina.move()` method can be used to wrap and
+mark transferable values such that they will by transferred rather than
 cloned.
 
 The `value` may be any object supported by Node.js to be transferable
@@ -710,7 +710,7 @@ The `move()` method will throw if the `value` is not transferable.
 
 The object returned by the `move()` method should not be set as a
 nested value in an object. If it is used, the `move()` object itself
-will be cloned as opposed to transfering the object it wraps.
+will be cloned as opposed to transferring the object it wraps.
 
 #### Interface: `Transferable`
 

--- a/docs/docs/api-reference/class.md
+++ b/docs/docs/api-reference/class.md
@@ -54,10 +54,10 @@ This class extends [`EventEmitter`](https://nodejs.org/api/events.html) from Nod
   - `atomics`: (`sync` | `async` | `disabled`) Use the [`Atomics`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics) API for faster communication
     between threads. This is on by default. You can disable `Atomics` globally by
     setting the environment variable `PISCINA_DISABLE_ATOMICS` to `1` .
-    If `atomics` is `sync`, it will cause to pause threads (stoping all execution)
+    If `atomics` is `sync`, it will cause to pause threads (stopping all execution)
     between tasks. Ideally, threads should wait for all operations to finish before
     returning control to the main thread (avoid having open handles within a thread). If still want to have the possibility
-    of having open handles or handle asynchrnous tasks, you can set the environment variable `PISCINA_ENABLE_ASYNC_ATOMICS` to `1` or setting `options.atomics` to `async`.
+    of having open handles or handle asynchronous tasks, you can set the environment variable `PISCINA_ENABLE_ASYNC_ATOMICS` to `1` or setting `options.atomics` to `async`.
 
     :::info
     **Note**: The `async` mode comes with performance penalties and can lead to undesired behaviour if open handles are not tracked correctly.
@@ -113,7 +113,7 @@ This class extends [`EventEmitter`](https://nodejs.org/api/events.html) from Nod
 
 :::info
   **Note on Explicit Resource Management**: Piscina does has support for `Symbol.dispose` and `Symbol.asyncDispose` for explicit resource management for its usage with the `using` keyword.
-  This is only avaiable on Node.js 24 and higher.
+  This is only available on Node.js 24 and higher.
 
   For more information, see the [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management).
 :::

--- a/docs/docs/api-reference/static-property.md
+++ b/docs/docs/api-reference/static-property.md
@@ -15,8 +15,8 @@ Provides the current version of this library as a semver string.
 
 By default, any value returned by a worker function will be cloned when
 returned back to the Piscina pool, even if that object is capable of
-being transfered. The `Piscina.move()` method can be used to wrap and
-mark transferable values such that they will by transfered rather than
+being transferred. The `Piscina.move()` method can be used to wrap and
+mark transferable values such that they will by transferred rather than
 cloned.
 
 The `value` may be any object supported by Node.js to be transferable
@@ -35,4 +35,4 @@ The `move()` method will throw if the `value` is not transferable.
 
 The object returned by the `move()` method should not be set as a
 nested value in an object. If it is used, the `move()` object itself
-will be cloned as opposed to transfering the object it wraps.
+will be cloned as opposed to transferring the object it wraps.

--- a/docs/docs/examples/server.mdx
+++ b/docs/docs/examples/server.mdx
@@ -202,14 +202,14 @@ The reason `sync-sleep-pooled` and `async-sleep-pooled` yield identical results
 is because, in both cases, the main thread is doing identical work -- that is,
 receiving a request that is dispatched to a worker, waiting about 100 milliseconds,
 the returning the response. The main thread here does not care whether the workers
-are sleeping synchronously or asychronously.
+are sleeping synchronously or asynchronously.
 
 ## Tuning pool performance
 
 It is possible to tune the performance of the Piscina worker pool using a variety
 of options:
 
-* `minThreads` - The minimum number of threads always runnin
+* `minThreads` - The minimum number of threads always running
 * `maxThreads` - The maximum number of threads allowed
 * `idleTimeout` - The number of millisecondsa thread is permitted to remain idle
 * `maxQueue` -- The maximum number of pending work items

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -193,14 +193,14 @@ The reason `sync-sleep-pooled` and `async-sleep-pooled` yield identical results
 is because, in both cases, the main thread is doing identical work -- that is,
 receiving a request that is dispatched to a worker, waiting about 100 milliseconds,
 the returning the response. The main thread here does not care whether the workers
-are sleeping synchronously or asychronously.
+are sleeping synchronously or asynchronously.
 
 ## Tuning pool performance
 
 It is possible to tune the performance of the Piscina worker pool using a variety
 of options:
 
-* `minThreads` - The minimum number of threads always runnin
+* `minThreads` - The minimum number of threads always running
 * `maxThreads` - The maximum number of threads allowed
 * `idleTimeout` - The number of millisecondsa thread is permitted to remain idle
 * `maxQueue` -- The maximum number of pending work items

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -79,7 +79,7 @@ const args = [
 let result
 
 // we skip coverage for node 20
-// because this issuse happen https://github.com/nodejs/node/pull/53315
+// because this issue happen https://github.com/nodejs/node/pull/53315
 if (isCoverage && !process.version.startsWith('v20.')) {
   log('Running tests with coverage')
   result = spawnSync(

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,7 +3,7 @@ import { availableParallelism } from 'node:os';
 
 import { kMovable, kTransferable, kValue } from './symbols';
 
-// States wether the worker is ready to receive tasks
+// States whether the worker is ready to receive tasks
 export const READY = '_WORKER_READY';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,7 +943,7 @@ export default class Piscina<Exports extends Record<string, (payload: any) => an
     const capacity = this.duration * this.#pool.options.maxThreads;
     const totalMeanRuntime = (this.#pool.histogram.runTimeSummary.mean / 1000) * count;
 
-    // We calculate the appoximate pool utilization by multiplying
+    // We calculate the approximate pool utilization by multiplying
     // the mean run time of all tasks by the number of runtime
     // samples taken and dividing that by the capacity. The
     // theory here is that capacity represents the absolute upper

--- a/src/worker_pool/balancer/index.ts
+++ b/src/worker_pool/balancer/index.ts
@@ -4,7 +4,7 @@ import type { PiscinaWorker } from '..';
 export type PiscinaLoadBalancer = (
   task: PiscinaTask,
   workers: PiscinaWorker[]
-) => PiscinaWorker | null; // If candidate is passed, it will be used as the result of the load balancer and ingore the command;
+) => PiscinaWorker | null; // If candidate is passed, it will be used as the result of the load balancer and ignore the command;
 
 export type LeastBusyBalancerOptions = {
   maximumUsage: number;

--- a/src/worker_pool/index.ts
+++ b/src/worker_pool/index.ts
@@ -117,7 +117,7 @@ export class WorkerInfo extends AsynchronouslyCreatedResource {
     }
 
     setIdleTimeout (handler: (_: void) => void, ms: number, ...args: any[]) : void {
-      // @ts-expect-error - refering to node.js timers
+      // @ts-expect-error - referring to node.js timers
       this.idleTimeout = setTimeout(handler, ms, ...args).unref();
     }
 


### PR DESCRIPTION
Fixes the documentation and code-comment typos listed in #1063. Changelog files were left untouched as requested.

Closes #1063.