### PR TITLE
fix: correct typo 'maintanance' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Declaring formal releases remains the prerogative of the project maintainer.
 ## Previous Versions
 Every version of Piscina has its own branch. All Piscina related changes should be based on the corresponding branch.
 
-Piscina's adhere to one active release line and a maintanance release line within a single year, rotating on a yearly basis.
+Piscina's adhere to one active release line and a maintenance release line within a single year, rotating on a yearly basis.
 
 Version	| Branch | Status
 ------- | ------ | ------


### PR DESCRIPTION
Fixes a spelling error in CONTRIBUTING.md: `maintanance` → `maintenance`. This is one of the typos identified in #1063.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._