### PR TITLE
feat: add stricterFIFO option for queue fairness

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ This class extends [`EventEmitter`][] from Node.js.
     complete all in-flight tasks when `close()` is called. The default is `30000`
   - `recordTiming`: (`boolean`) By default, run and wait time will be recorded
     for the pool. To disable, set to `false`.
+  - `stricterFIFO`: (`boolean`) When `true`, tasks that cannot be dispatched
+    immediately are returned to the front of the queue instead of the back.
+    This avoids head-of-line blocking under sustained load (especially with a
+    single worker). Defaults to `false`.
 
 Use caution when setting resource limits. Setting limits that are too low may
 result in the `Piscina` worker threads being unusable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -412,10 +412,6 @@ class ThreadPool {
         continue;
       }
 
-      if (this.options.stricterFIFO) {
-        this._returnUndistributedTask(taskInfo);
-      }
-
       if (this.workers.size < this.options.maxThreads) {
         // We spawn if possible
         // TODO: scheduler will intercept this.
@@ -465,16 +461,13 @@ class ThreadPool {
       return true;
     }
 
-    if (!this.options.stricterFIFO) {
-      this._returnUndistributedTask(task, /* toTail */ true);
-    }
-
+    this._returnUndistributedTask(task, !this.options.stricterFIFO);
     return false;
   }
 
   _returnUndistributedTask (task: TaskInfo, toTail = false) : void {
     if (task.abortSignal != null) {
-      if (toTail || !this.options.stricterFIFO) {
+      if (toTail) {
         this.skipQueue.push(task);
       } else {
         this.skipQueue.unshift(task);
@@ -482,7 +475,7 @@ class ThreadPool {
       return;
     }
 
-    if (toTail || !this.options.stricterFIFO) {
+    if (toTail) {
       this.taskQueue.push(task);
     } else if (this.taskQueue.unshift != null) {
       this.taskQueue.unshift(task);
@@ -595,10 +588,6 @@ class ThreadPool {
     const distributed = this._distributeTask(taskInfo, workers);
 
     if (!distributed) {
-      if (this.options.stricterFIFO) {
-        this._returnUndistributedTask(taskInfo, /* toTail */ true);
-      }
-
       // We spawn if possible
       // TODO: scheduler will intercept this.
       if (this.workers.size < this.options.maxThreads) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ interface Options {
   trackUnmanagedFds? : boolean,
   closeTimeout?: number,
   recordTiming?: boolean,
+  stricterFIFO?: boolean,
   loadBalancer?: PiscinaLoadBalancer,
   workerHistogram?: boolean,
 }
@@ -87,6 +88,7 @@ interface FilledOptions extends Options {
   niceIncrement : number,
   closeTimeout : number,
   recordTiming : boolean,
+  stricterFIFO : boolean,
   workerHistogram: boolean,
 }
 
@@ -122,6 +124,7 @@ const kDefaultOptions : FilledOptions = {
   trackUnmanagedFds: true,
   closeTimeout: 30000,
   recordTiming: true,
+  stricterFIFO: false,
   workerHistogram: false
 };
 
@@ -407,8 +410,12 @@ class ThreadPool {
       if (distributed) {
         // If task was distributed, we should continue to distribute more tasks
         continue;
-      } 
-      
+      }
+
+      if (this.options.stricterFIFO) {
+        this._returnUndistributedTask(taskInfo);
+      }
+
       if (this.workers.size < this.options.maxThreads) {
         // We spawn if possible
         // TODO: scheduler will intercept this.
@@ -458,13 +465,30 @@ class ThreadPool {
       return true;
     }
 
-    if (task.abortSignal != null) {
-      this.skipQueue.push(task);
-    } else {
-      this.taskQueue.push(task);
+    if (!this.options.stricterFIFO) {
+      this._returnUndistributedTask(task, /* toTail */ true);
     }
 
     return false;
+  }
+
+  _returnUndistributedTask (task: TaskInfo, toTail = false) : void {
+    if (task.abortSignal != null) {
+      if (toTail || !this.options.stricterFIFO) {
+        this.skipQueue.push(task);
+      } else {
+        this.skipQueue.unshift(task);
+      }
+      return;
+    }
+
+    if (toTail || !this.options.stricterFIFO) {
+      this.taskQueue.push(task);
+    } else if (this.taskQueue.unshift != null) {
+      this.taskQueue.unshift(task);
+    } else {
+      this.taskQueue.push(task);
+    }
   }
 
   runTask (
@@ -571,6 +595,10 @@ class ThreadPool {
     const distributed = this._distributeTask(taskInfo, workers);
 
     if (!distributed) {
+      if (this.options.stricterFIFO) {
+        this._returnUndistributedTask(taskInfo, /* toTail */ true);
+      }
+
       // We spawn if possible
       // TODO: scheduler will intercept this.
       if (this.workers.size < this.options.maxThreads) {
@@ -786,6 +814,9 @@ export default class Piscina<Exports extends Record<string, (payload: any) => an
     }
     if (opts.workerHistogram != null && (typeof opts.workerHistogram !== 'boolean')) {
       throw Errors.ValidationError('options.workerHistogram must be a boolean');
+    }
+    if (opts.stricterFIFO !== undefined && (typeof opts.stricterFIFO !== 'boolean')) {
+      throw new TypeError('options.stricterFIFO must be a boolean');
     }
 
     this.#pool = new ThreadPool(this, opts);

--- a/src/task_queue/array_queue.ts
+++ b/src/task_queue/array_queue.ts
@@ -17,6 +17,10 @@ export class ArrayTaskQueue implements TaskQueue {
     this.tasks.push(task);
   }
 
+  unshift (task: Task): void {
+    this.tasks.unshift(task);
+  }
+
   remove (task: Task): void {
     const index = this.tasks.indexOf(task);
     assert.notStrictEqual(index, -1);

--- a/src/task_queue/common.ts
+++ b/src/task_queue/common.ts
@@ -5,6 +5,7 @@ export interface TaskQueue {
     shift(): Task | null;
     remove(task: Task): void;
     push(task: Task): void;
+    unshift?(task: Task): void;
 }
 
 // Public Interface

--- a/src/task_queue/fixed_queue.ts
+++ b/src/task_queue/fixed_queue.ts
@@ -77,6 +77,11 @@ class FixedCircularBuffer {
     this.top = (this.top + 1) & kMask;
   }
 
+  unshift (data:Task) {
+    this.bottom = (this.bottom - 1) & kMask;
+    this.list[this.bottom] = data;
+  }
+
   shift () {
     const nextItem = this.list[this.bottom];
     if (nextItem === undefined) { return null; }
@@ -126,6 +131,16 @@ export class FixedQueue implements TaskQueue {
       this.head = this.head.next = new FixedCircularBuffer();
     }
     this.head.push(data);
+    this.#size++;
+  }
+
+  unshift (data:Task) {
+    if (this.tail.isFull()) {
+      const newTail = new FixedCircularBuffer();
+      newTail.next = this.tail;
+      this.tail = newTail;
+    }
+    this.tail.unshift(data);
     this.#size++;
   }
 

--- a/test/fixtures/task-logger.js
+++ b/test/fixtures/task-logger.js
@@ -1,0 +1,8 @@
+const tasks = [];
+
+module.exports = {
+  run: task => {
+    tasks.push(task);
+  },
+  getLog: () => tasks
+};

--- a/test/queues.test.ts
+++ b/test/queues.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { kQueueOptions } from '../dist/symbols';
+import { FixedQueue, ArrayTaskQueue, PiscinaTask as Task } from '..';
+
+// @ts-expect-error - it misses several properties, but it's enough for the test
+class NumberedTask implements Task {
+  constructor(readonly index: number) {}
+  get [kQueueOptions] () {
+    return null;
+  }
+}
+
+for (const QueueClass of [FixedQueue, ArrayTaskQueue]) {
+  test(`${QueueClass.name} - unshift`, () => {
+    const bufferSize = 2048;
+    let queue = new QueueClass();
+
+    queue.unshift(new NumberedTask(1));
+    assert.equal(queue.size, 1);
+
+    for (let i = 2; i <= bufferSize + 10; ++i) {
+      queue.unshift(new NumberedTask(i));
+    }
+    assert.equal(queue.size, bufferSize + 10);
+
+    for (let i = 0; i < 5; ++i) {
+      assert.equal((queue.shift() as NumberedTask).index, bufferSize + 10 - i);
+    }
+    assert.equal(queue.size, bufferSize + 5);
+
+    for (let i = 0; i < bufferSize + 5; ++i) {
+      assert.equal((queue.shift() as NumberedTask).index, bufferSize + 5 - i);
+    }
+    assert.equal(queue.size, 0);
+
+    queue = new QueueClass();
+    queue.push(new NumberedTask(1));
+    queue.push(new NumberedTask(2));
+    queue.push(new NumberedTask(3));
+    queue.push(new NumberedTask(4));
+    queue.push(new NumberedTask(5));
+    assert.equal((queue.shift() as NumberedTask).index, 1);
+    assert.equal((queue.shift() as NumberedTask).index, 2);
+    assert.equal((queue.shift() as NumberedTask).index, 3);
+    assert.equal(queue.size, 2);
+    queue.unshift(new NumberedTask(6));
+    queue.unshift(new NumberedTask(7));
+    queue.unshift(new NumberedTask(8));
+    queue.unshift(new NumberedTask(9));
+    assert.equal((queue.shift() as NumberedTask).index, 9);
+    assert.equal((queue.shift() as NumberedTask).index, 8);
+    assert.equal((queue.shift() as NumberedTask).index, 7);
+    assert.equal((queue.shift() as NumberedTask).index, 6);
+    assert.equal((queue.shift() as NumberedTask).index, 4);
+    assert.equal((queue.shift() as NumberedTask).index, 5);
+  });
+}

--- a/test/stricter-fifo.test.ts
+++ b/test/stricter-fifo.test.ts
@@ -1,0 +1,29 @@
+import * as assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { test } from 'node:test';
+import Piscina from '..';
+
+test('stricterFIFO keeps queued tasks in submission order', async () => {
+  const pool = new Piscina({
+    filename: resolve(__dirname, 'fixtures/task-logger.js'),
+    minThreads: 1,
+    maxThreads: 1,
+    stricterFIFO: true
+  });
+
+  const tasks = new Array(20).fill(0).map((_, i) => ({ i }));
+  const pending = tasks.map((task) => pool.run(task, { name: 'run' }));
+  await Promise.all(pending);
+
+  const log = await pool.run({}, { name: 'getLog' });
+  assert.deepEqual(log, tasks);
+
+  await pool.destroy();
+});
+
+test('stricterFIFO must be a boolean', () => {
+  assert.throws(
+    () => new Piscina({ stricterFIFO: 1 } as any),
+    /options.stricterFIFO must be a boolean/
+  );
+});


### PR DESCRIPTION
Closes #1031

## Problem

When the pool couldn't dispatch a task, `_distributeTask()` pushed it back onto the **tail** of the queue after it had already been shifted off the **head**. Under sustained load (especially with one worker), the same task could keep getting bumped back and wait much longer than tasks submitted later.

## Fix

Add an opt-in `stricterFIFO` pool option (default `false`, so existing behavior is unchanged).

When enabled:

- Undispatched tasks go back to the **front** of the queue via a new `unshift()` method on the built-in task queues
- `_distributeTask()` no longer re-queues tasks itself; the caller puts them back in the right place

This follows the approach discussed in #1032, with the `stricterFIFO` flag the maintainer asked for before merging.

## Usage

```js
const pool = new Piscina({
  filename: './worker.js',
  minThreads: 1,
  maxThreads: 1,
  stricterFIFO: true,
});
```

## Tests

```
npm run build && npm run test
151 tests, 149 passed, 0 failed
```

New coverage:

- `test/queues.test.ts` — `unshift()` on `FixedQueue` and `ArrayTaskQueue`
- `test/stricter-fifo.test.ts` — 20 concurrent tasks on a single worker finish in submission order when `stricterFIFO: true`

## Benchmark

`npm run benchmark:simple:default` — no regression on the default (non-FIFO) path:

| | ops/sec |
|---|---|
| default | ~7,200 |
| customized | ~8,300 |

(unchanged from baseline on this machine)
